### PR TITLE
Support port-offset system property for management port

### DIFF
--- a/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/CommonDomainContainerConfiguration.java
+++ b/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/CommonDomainContainerConfiguration.java
@@ -47,7 +47,7 @@ public class CommonDomainContainerConfiguration implements ContainerConfiguratio
 
     public CommonDomainContainerConfiguration() {
         managementAddress = getInetAddress("127.0.0.1");
-        managementPort = 9990;
+        managementPort = 9990 + Integer.decode(System.getProperty("jboss.socket.binding.port-offset", "0"));
     }
 
     public InetAddress getManagementAddress() {

--- a/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerConfiguration.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerConfiguration.java
@@ -39,7 +39,7 @@ public class CommonContainerConfiguration implements ContainerConfiguration {
 
     public CommonContainerConfiguration() {
         managementAddress = "127.0.0.1";
-        managementPort = 9990;
+        managementPort = 9990 + Integer.decode(System.getProperty("jboss.socket.binding.port-offset", "0"));
     }
 
     public String getManagementAddress() {


### PR DESCRIPTION
This simple change allows to offset the management port in a similar fashion as you would do for WildFly. This allows us to start multiple WildFly instances at different port-offsets and select one without changing arquillian.xml, for example from a build script.
