### PR TITLE
WFLY-3882 ManagementClient Domain Hosts

### DIFF
--- a/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
+++ b/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
@@ -47,7 +47,6 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import javax.management.MBeanServerConnection;
@@ -237,13 +236,8 @@ public class ManagementClient {
         readRootNode();
 
         if (rootNode.isDefined())
-            if (rootNode.get("host").isDefined()){
-                List<ModelNode> listNodes = rootNode.get("host").asList();
-
-                for (ModelNode listNode : listNodes) {
-                    hosts.add(listNode.keys().toString());
-                }
-            }
+            if (rootNode.hasDefined("host"))
+                hosts.addAll(rootNode.get("host").keys());
 
         return hosts;
     }


### PR DESCRIPTION
Addition of a function at ManagementClient that returns the hosts that are included in the domain.
