### PR TITLE
Allow domain servers to pass server arguments

### DIFF
--- a/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainContainerConfiguration.java
+++ b/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainContainerConfiguration.java
@@ -37,6 +37,8 @@ public class ManagedDomainContainerConfiguration extends CommonDomainContainerCo
 
     private String javaVmArguments = System.getProperty("jboss.options");
 
+    private String jbossArguments;
+
     private int startupTimeoutInSeconds = 60;
 
     private int stopTimeoutInSeconds = 60;
@@ -114,6 +116,24 @@ public class ManagedDomainContainerConfiguration extends CommonDomainContainerCo
      */
     public void setJavaVmArguments(String javaVmArguments) {
         this.javaVmArguments = javaVmArguments;
+    }
+
+    /**
+     * A space delimited list of arguments to be passed to the server like command line options.
+     *
+     * @return the arguments the arguments to be passed or {@code null} if no arguments were set
+     */
+    public String getJbossArguments() {
+        return jbossArguments;
+    }
+
+    /**
+     * A space delimited list of arguments to be passed to the server like command line options.
+     *
+     * @param jbossArguments the space delimited arguments to set or {@code null} not pass any
+     */
+    public void setJbossArguments(String jbossArguments) {
+        this.jbossArguments = jbossArguments;
     }
 
     /**

--- a/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
+++ b/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
@@ -109,6 +109,12 @@ public class ManagedDomainDeployableContainer extends CommonDomainDeployableCont
                 commandBuilder.setHostConfiguration(config.getHostConfig());
             }
 
+            // Set server arguments if not null
+            final String serverArgs = config.getJbossArguments();
+            if (serverArgs != null) {
+                commandBuilder.addServerArguments(serverArgs.split("\\s+"));
+            }
+
             // Previous versions of arquillian set the jboss.home.dir property in the JVM properties.
             // Some tests may rely on this behavior, but could be considered to be removed as all the scripts add this
             // property after the modules path (-mp) has been defined. The command builder will set the property after


### PR DESCRIPTION
This will be needed for WildFly to pass `-secmgr` to domain servers.
