### PR TITLE
Use different version property for WildFly Core to ensure WildFly full doesn't override the version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <version.com.google.guava>16.0.1</version.com.google.guava>
-        <version.org.wildfly.core>1.0.0.CR2</version.org.wildfly.core>
+        <version.org.wildfly.core.arq>1.0.0.CR2</version.org.wildfly.core.arq>
         <version.org.wildfly.core.full>9.0.0.CR1</version.org.wildfly.core.full>
         <version.junit>4.12</version.junit>
         <version.org.jboss.arquillian.core>1.1.8.Final</version.org.jboss.arquillian.core>
@@ -188,14 +188,14 @@
                 <artifactId>wildfly-core-parent</artifactId>
                 <scope>import</scope>
                 <type>pom</type>
-                <version>${version.org.wildfly.core}</version>
+                <version>${version.org.wildfly.core.arq}</version>
             </dependency>
 
             <!-- workaround to make sure we dont use jboss-common-core -->
             <dependency>
                 <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-domain-management</artifactId>
-                <version>${version.org.wildfly.core}</version>
+                <version>${version.org.wildfly.core.arq}</version>
                 <scope>provided</scope>
                 <exclusions>
                     <exclusion>
@@ -215,7 +215,7 @@
             <dependency>
                 <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-launcher</artifactId>
-                <version>${version.org.wildfly.core}</version>
+                <version>${version.org.wildfly.core.arq}</version>
             </dependency>
 
             <dependency>

--- a/server-provisioning.xml
+++ b/server-provisioning.xml
@@ -21,6 +21,6 @@
   -->
 <server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" copy-module-artifacts="false">
     <feature-packs>
-        <feature-pack groupId="org.wildfly.core" artifactId="wildfly-core-feature-pack" version="${version.org.wildfly.core}" />
+        <feature-pack groupId="org.wildfly.core" artifactId="wildfly-core-feature-pack" version="${version.org.wildfly.core.arq}" />
     </feature-packs>
 </server-provisioning>


### PR DESCRIPTION
Currently wildfly-arquillian uses `version.org.wildfly.core` for the version property. WildFly full uses the same property which means dependencies during a WildFly build are overridden.