### PR TITLE
[WFLY-5003] try to locate undertow subsystem from ManagementClients i…

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
@@ -149,10 +149,19 @@ public class ManagementClient implements AutoCloseable, Closeable {
      */
     public URI getWebUri() {
         if (webUri == null) {
+            // fall back to default typical setting if we are unable to read it from undertow subsystem
             try {
                 webUri = new URI("http://localhost:8080");
             } catch (URISyntaxException e) {
                 throw new RuntimeException(e);
+            }
+
+            // try reading the URI from the undertow subsystem, if possible
+            if(undertowSubsystem == null) {
+                try {
+                    init();
+                } catch(Exception e) {
+                }
             }
             if (undertowSubsystem != null) {
                 List<Property> vhosts = undertowSubsystem.get("server").asPropertyList();


### PR DESCRIPTION
…njected into applications

ManagementClients injected into applications don't have the init() method called properly, which is supposed to locate the Undertow subsystem. When asked for the web root URI, they can't read it from Undertow subsystem and fall back to returning localhost:8080, which is not always correct. Now they will try to locate Undertow by calling init() if necessary.