### PR TITLE
[WFLY-4850] Catch AssertionError's in the isServerInRunningState() as…

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
@@ -216,9 +216,10 @@ public class ManagementClient implements AutoCloseable, Closeable {
             return SUCCESS.equals(rsp.get(OUTCOME).asString())
                     && !CONTROLLER_PROCESS_STATE_STARTING.equals(rsp.get(RESULT).asString())
                     && !CONTROLLER_PROCESS_STATE_STOPPING.equals(rsp.get(RESULT).asString());
-        } catch (RuntimeException rte) {
-            throw rte;
-        } catch (IOException ex) {
+        } catch (IOException | AssertionError ex) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Failed to execution operation.", ex);
+            }
             return false;
         }
     }


### PR DESCRIPTION
… they shouldn't cause failures in tests where the server isn't running.

https://issues.jboss.org/browse/WFLY-4850