### PR TITLE
WFLY-4255 Properly name classes servicing WildFlyContainerController …

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerExtension.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerExtension.java
@@ -20,8 +20,8 @@ import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTr
 import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.arquillian.test.spi.TestEnricher;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
-import org.jboss.as.arquillian.container.controller.WildFlyClientContainerControllerCreator;
-import org.jboss.as.arquillian.container.controller.WildFlyClientContainerControllerProvider;
+import org.jboss.as.arquillian.container.controller.ClientWildFlyContainerControllerCreator;
+import org.jboss.as.arquillian.container.controller.ClientWildFlyContainerControllerProvider;
 import org.jboss.as.arquillian.container.controller.WildFlyContainerLifecycleController;
 import org.jboss.as.arquillian.container.controller.command.WildFlyContainerCommandObserver;
 
@@ -44,8 +44,8 @@ public class CommonContainerExtension implements LoadableExtension {
 
         // WildFlyContainerController
         builder
-                .service(ResourceProvider.class, WildFlyClientContainerControllerProvider.class)
-                .observer(WildFlyClientContainerControllerCreator.class)
+                .service(ResourceProvider.class, ClientWildFlyContainerControllerProvider.class)
+                .observer(ClientWildFlyContainerControllerCreator.class)
                 .observer(WildFlyContainerCommandObserver.class)
                 .observer(WildFlyContainerLifecycleController.class)
         ;

--- a/common/src/main/java/org/jboss/as/arquillian/container/controller/ClientWildFlyContainerController.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/controller/ClientWildFlyContainerController.java
@@ -34,14 +34,14 @@ import org.jboss.arquillian.container.test.impl.client.container.ClientContainer
 import org.jboss.as.arquillian.api.WildFlyContainerController;
 
 /**
- * WildFlyClientContainerController
+ * Implementation of {@link WildFlyContainerController} used from client.
  *
  * @author Radoslav Husar
  * @version Jan 2015
  */
-public class WildFlyClientContainerController extends ClientContainerController implements WildFlyContainerController {
+public class ClientWildFlyContainerController extends ClientContainerController implements WildFlyContainerController {
 
-    private final Logger log = Logger.getLogger(WildFlyClientContainerController.class.getName());
+    private final Logger log = Logger.getLogger(ClientWildFlyContainerController.class.getName());
 
     /**
      * @see org.jboss.arquillian.container.test.impl.client.container.ClientContainerController#stop(java.lang.String)

--- a/common/src/main/java/org/jboss/as/arquillian/container/controller/ClientWildFlyContainerControllerCreator.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/controller/ClientWildFlyContainerControllerCreator.java
@@ -32,12 +32,12 @@ import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.as.arquillian.api.WildFlyContainerController;
 
 /**
- * WildFlyClientContainerControllerCreator
+ * Produces instances of WildFlyContainerController when running as client.
  *
  * @author Radoslav Husar
  * @version Jan 2015
  */
-public class WildFlyClientContainerControllerCreator {
+public class ClientWildFlyContainerControllerCreator {
 
     @Inject
     @ApplicationScoped
@@ -48,7 +48,7 @@ public class WildFlyClientContainerControllerCreator {
 
     @SuppressWarnings("UnusedParameters")
     public void create(@Observes SetupContainers event) {
-        controller.set(injector.get().inject(new WildFlyClientContainerController()));
+        controller.set(injector.get().inject(new ClientWildFlyContainerController()));
     }
 }
 

--- a/common/src/main/java/org/jboss/as/arquillian/container/controller/ClientWildFlyContainerControllerProvider.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/controller/ClientWildFlyContainerControllerProvider.java
@@ -21,33 +21,38 @@
  */
 package org.jboss.as.arquillian.container.controller;
 
-import org.jboss.arquillian.core.api.Injector;
+import java.lang.annotation.Annotation;
+
 import org.jboss.arquillian.core.api.Instance;
-import org.jboss.arquillian.core.api.InstanceProducer;
-import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
-import org.jboss.arquillian.core.api.annotation.Observes;
-import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 import org.jboss.as.arquillian.api.WildFlyContainerController;
 
 /**
- * WildFlyContainerContainerControllerCreator
+ * ResourceProvider for WildFlyContainerController instances for injections running as client.
  *
  * @author Radoslav Husar
  * @version Jan 2015
  */
-public class WildFlyContainerContainerControllerCreator {
+public class ClientWildFlyContainerControllerProvider implements ResourceProvider {
 
     @Inject
-    @ApplicationScoped
-    private InstanceProducer<WildFlyContainerController> controller;
+    private Instance<WildFlyContainerController> controller;
 
-    @Inject
-    private Instance<Injector> injector;
+    /**
+     * @see org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider#lookup(org.jboss.arquillian.test.api.ArquillianResource, java.lang.annotation.Annotation...)
+     */
+    @Override
+    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
+        return controller.get();
+    }
 
-    @SuppressWarnings("UnusedParameters")
-    public void create(@Observes BeforeSuite event) {
-        controller.set(injector.get().inject(new WildFlyContainerContainerController()));
+    /**
+     * @see org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider#canProvide(Class)
+     */
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return type.isAssignableFrom(WildFlyContainerController.class);
     }
 }
-

--- a/common/src/main/java/org/jboss/as/arquillian/container/controller/InContainerWildFlyContainerController.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/controller/InContainerWildFlyContainerController.java
@@ -26,12 +26,13 @@ import org.jboss.as.arquillian.api.WildFlyContainerController;
 import org.jboss.as.arquillian.container.controller.command.StopWithTimeoutContainerCommand;
 
 /**
- * WildFlyContainerContainerController
+ * {@link org.jboss.arquillian.container.test.api.ContainerController} running in container executing {@link org.jboss.arquillian.container.test.spi.command.Command}s
+ * over the {@link org.jboss.arquillian.container.test.spi.command.CommandService}.
  *
  * @author Radoslav Husar
  * @version Jan 2015
  */
-public class WildFlyContainerContainerController extends ContainerContainerController implements WildFlyContainerController {
+public class InContainerWildFlyContainerController extends ContainerContainerController implements WildFlyContainerController {
 
     @Override
     public void stop(String containerQualifier, int timeout) {

--- a/common/src/main/java/org/jboss/as/arquillian/container/controller/InContainerWildFlyContainerControllerCreator.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/controller/InContainerWildFlyContainerControllerCreator.java
@@ -21,38 +21,33 @@
  */
 package org.jboss.as.arquillian.container.controller;
 
-import java.lang.annotation.Annotation;
-
+import org.jboss.arquillian.core.api.Injector;
 import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
 import org.jboss.as.arquillian.api.WildFlyContainerController;
 
 /**
- * WildFlyContainerContainerControllerProvider
+ * Produces instances of WildFlyContainerController when running in container.
  *
  * @author Radoslav Husar
  * @version Jan 2015
  */
-public class WildFlyContainerContainerControllerProvider implements ResourceProvider {
+public class InContainerWildFlyContainerControllerCreator {
 
     @Inject
-    private Instance<WildFlyContainerController> controller;
+    @ApplicationScoped
+    private InstanceProducer<WildFlyContainerController> controller;
 
-    /**
-     * @see org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider#lookup(org.jboss.arquillian.test.api.ArquillianResource, java.lang.annotation.Annotation...)
-     */
-    @Override
-    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return controller.get();
-    }
+    @Inject
+    private Instance<Injector> injector;
 
-    /**
-     * @see org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider#canProvide(java.lang.Class)
-     */
-    @Override
-    public boolean canProvide(Class<?> type) {
-        return type.isAssignableFrom(WildFlyContainerController.class);
+    @SuppressWarnings("UnusedParameters")
+    public void create(@Observes BeforeSuite event) {
+        controller.set(injector.get().inject(new InContainerWildFlyContainerController()));
     }
 }
+

--- a/common/src/main/java/org/jboss/as/arquillian/container/controller/InContainerWildFlyContainerControllerProvider.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/controller/InContainerWildFlyContainerControllerProvider.java
@@ -30,12 +30,12 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 import org.jboss.as.arquillian.api.WildFlyContainerController;
 
 /**
- * WildFlyClientContainerControllerProvider
+ * ResourceProvider for WildFlyContainerController instances for injections running in container.
  *
  * @author Radoslav Husar
  * @version Jan 2015
  */
-public class WildFlyClientContainerControllerProvider implements ResourceProvider {
+public class InContainerWildFlyContainerControllerProvider implements ResourceProvider {
 
     @Inject
     private Instance<WildFlyContainerController> controller;
@@ -49,7 +49,7 @@ public class WildFlyClientContainerControllerProvider implements ResourceProvide
     }
 
     /**
-     * @see org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider#canProvide(Class)
+     * @see org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider#canProvide(java.lang.Class)
      */
     @Override
     public boolean canProvide(Class<?> type) {

--- a/common/src/main/java/org/jboss/as/arquillian/container/controller/StopContainerWithTimeout.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/controller/StopContainerWithTimeout.java
@@ -25,7 +25,7 @@ import org.jboss.arquillian.container.spi.Container;
 import org.jboss.arquillian.container.spi.event.ContainerControlEvent;
 
 /**
- * StopContainerWithTimeout coming from {@link WildFlyClientContainerController#stop(java.lang.String, int)}.
+ * {@link ContainerControlEvent} implementation fired in {@link ClientWildFlyContainerController#stop(java.lang.String, int)}.
  *
  * @author Radoslav Husar
  * @version Jan 2015
@@ -34,6 +34,10 @@ public class StopContainerWithTimeout extends ContainerControlEvent {
 
     private int timeout;
 
+    /**
+     * @param container container to stop
+     * @param timeout   graceful shutdown timeout in seconds
+     */
     public StopContainerWithTimeout(Container container, int timeout) {
         super(container);
         this.timeout = timeout;

--- a/common/src/main/java/org/jboss/as/arquillian/container/controller/WildFlyContainerControllerRemoteExtension.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/controller/WildFlyContainerControllerRemoteExtension.java
@@ -35,8 +35,8 @@ public class WildFlyContainerControllerRemoteExtension implements RemoteLoadable
     @Override
     public void register(ExtensionBuilder builder) {
         builder
-                .service(ResourceProvider.class, WildFlyContainerContainerControllerProvider.class)
-                .observer(WildFlyContainerContainerControllerCreator.class)
+                .service(ResourceProvider.class, InContainerWildFlyContainerControllerProvider.class)
+                .observer(InContainerWildFlyContainerControllerCreator.class)
         ;
     }
 }

--- a/common/src/main/java/org/jboss/as/arquillian/container/controller/command/StopWithTimeoutContainerCommand.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/controller/command/StopWithTimeoutContainerCommand.java
@@ -24,7 +24,7 @@ package org.jboss.as.arquillian.container.controller.command;
 import org.jboss.arquillian.container.test.impl.client.deployment.command.AbstractCommand;
 
 /**
- * StopWithTimeoutContainerCommand coming from {@link org.jboss.as.arquillian.container.controller.WildFlyContainerContainerController}.
+ * StopWithTimeoutContainerCommand coming from {@link org.jboss.as.arquillian.container.controller.InContainerWildFlyContainerController}.
  *
  * @author Radoslav Husar
  * @version Jan 2015


### PR DESCRIPTION
…ity and improve JavaDoc

@jamezp One more thing, I realized the implementation class names are actually mangled because they mostly followed naming from upstream arquillian, which is extremely confusing. The names are now around the formula as we use elsewhere, so around:

[InContainer/Client]+WildFlyContainerController+[suffix]