### PR TITLE
Don't add JVM options set them instead. This was the behavior previou…

### DIFF
--- a/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
+++ b/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
@@ -84,8 +84,8 @@ public class ManagedDomainDeployableContainer extends CommonDomainDeployableCont
             final DomainCommandBuilder commandBuilder = DomainCommandBuilder.of(config.getJbossHome(), config.getJavaHome());
             if (config.getJavaVmArguments() != null) {
                 final String[] javaOpts = config.getJavaVmArguments().split("\\s+");
-                commandBuilder.addProcessControllerJavaOptions(javaOpts)
-                        .addHostControllerJavaOptions(javaOpts);
+                commandBuilder.setProcessControllerJavaOptions(javaOpts)
+                        .setHostControllerJavaOptions(javaOpts);
             }
 
             if (config.isSetupCleanServerBaseDir() || config.getCleanServerBaseDir() != null) {

--- a/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
+++ b/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
@@ -96,12 +96,12 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
                 log.warning("Bundles path is deprecated and no longer used.");
             }
 
-            final String additionalJavaOpts = config.getJavaVmArguments();
-            final String additionalJbossOpts = config.getJbossArguments();
+            final String javaOpts = config.getJavaVmArguments();
+            final String jbossArguments = config.getJbossArguments();
 
             commandBuilder.setJavaHome(config.getJavaHome());
-            if (additionalJavaOpts != null) {
-                commandBuilder.addJavaOptions(additionalJavaOpts.split("\\s+"));
+            if (javaOpts != null) {
+                commandBuilder.setJavaOptions(javaOpts.split("\\s+"));
             }
 
             if (config.isEnableAssertions()) {
@@ -116,8 +116,8 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
             if (config.isAdminOnly())
                 commandBuilder.setAdminOnly();
 
-            if (additionalJbossOpts != null) {
-                commandBuilder.addServerArguments(additionalJbossOpts.split("\\s+"));
+            if (jbossArguments != null) {
+                commandBuilder.addServerArguments(jbossArguments.split("\\s+"));
             }
 
             if (config.getServerConfig() != null) {


### PR DESCRIPTION
…s versions of jboss-arquillian and wildfly-arquillian used. Also renamed the variables to better suit their intention.

Previous PR was https://github.com/wildfly/wildfly-arquillian/pull/57 but I deleted my branch before I merged it.