### PR TITLE
WFARQ-4 When reading IP address, if its 0.0.0.0 convert to 127.0.0.1.

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -80,5 +80,9 @@
             <groupId>org.jboss.shrinkwrap.descriptors</groupId>
             <artifactId>shrinkwrap-descriptors-impl-base</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
@@ -83,7 +83,7 @@ import org.jboss.logging.Logger;
  * </p>
  * @author <a href="aslak@redhat.com">Aslak Knutsen</a>
  */
-public class ManagementClient implements AutoCloseable, Closeable {
+public class ManagementClient implements Closeable {
 
     private static final Logger logger = Logger.getLogger(ManagementClient.class);
 
@@ -311,10 +311,7 @@ public class ManagementClient implements AutoCloseable, Closeable {
             operation.get("include-runtime").set(true);
             ModelNode binding = executeForResult(operation);
             String ip = binding.get("bound-address").asString();
-            //it appears some system can return a binding with the zone specifier on the end
-            if (ip.contains(":") && ip.contains("%")) {
-                ip = ip.split("%")[0];
-            }
+            ip = formatIP(ip);
 
             final int port = defined(binding.get("bound-port"), socketBindingGroupName + " -> " + socketBinding + " -> bound-port is undefined").asInt();
 
@@ -322,6 +319,18 @@ public class ManagementClient implements AutoCloseable, Closeable {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    static String formatIP(String ip) {
+        //it appears some system can return a binding with the zone specifier on the end
+        if (ip.contains(":") && ip.contains("%")) {
+            ip = ip.split("%")[0];
+        }
+        if (ip.equals("0.0.0.0")) {
+            logger.debug("WildFly is bound to 0.0.0.0 which is correct, setting client to 127.0.0.1");
+            ip = "127.0.0.1";
+        }
+        return ip;
     }
 
     //-------------------------------------------------------------------------------------||

--- a/common/src/test/java/org/jboss/as/arquillian/container/ManagementClientTest.java
+++ b/common/src/test/java/org/jboss/as/arquillian/container/ManagementClientTest.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ManagementClientTest {
+
+    @Test
+    public void shouldParseBindAllAsLocalhost() {
+        String sourceIp = "0.0.0.0";
+        String parsedIp = ManagementClient.formatIP(sourceIp);
+        Assert.assertEquals("127.0.0.1", parsedIp);
+    }
+
+    @Test
+    public void shouldParseLocalIPAsNormalIP() {
+        String sourceIp = "10.1.2.3";
+        String formattedIp = ManagementClient.formatIP(sourceIp);
+        Assert.assertEquals(sourceIp, formattedIp);
+    }
+}


### PR DESCRIPTION
I couldn't come up with a better test case because of some structural issues.

- This bug only replicates when protocol == servlet, but all of these tests run as JMX.
- Switching to the servlet protocol didn't work, i'm not sure if there are classpath issues or what.  Need to look at the logs closer.
- Creating a dedicated module to test this didn't make much sense either.