### PR TITLE
Improves error message when mgmt port is in use

### DIFF
--- a/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
+++ b/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
@@ -321,12 +321,12 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
         final int managementPort = getContainerConfiguration().getManagementPort();
         throw new LifecycleException(
                 String.format("The port %1$d is already in use. It means that either the server might be already running " +
-                                "or there is another process using port %1$d.\n" +
+                                "or there is another process using port %1$d.%n" +
                                 "Managed containers do not support connecting to running server instances due to the " +
-                                "possible harmful effect of connecting to the wrong server.\n" +
+                                "possible harmful effect of connecting to the wrong server.%n" +
                                 "Please stop server (or another process) before running, " +
                                 "change to another type of container (e.g. remote) or use jboss.socket.binding.port-offset variable " +
-                                "to change the default port.\n" +
+                                "to change the default port.%n" +
                                 "To disable this check and allow Arquillian to connect to a running server, " +
                                 "set allowConnectingToRunningServer to true in the container configuration",
                         managementPort));

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <version.org.wildfly.core>2.0.10.Final</version.org.wildfly.core>
         <version.org.wildfly.core.full>10.0.0.Final</version.org.wildfly.core.full>
         <version.junit>4.12</version.junit>
-        <version.org.jboss.arquillian.core>1.1.10.Final</version.org.jboss.arquillian.core>
+        <version.org.jboss.arquillian.core>1.1.11.Final</version.org.jboss.arquillian.core>
         <version.org.wildfly.plugins.wildfly-maven-plugin>1.1.0.Alpha9</version.org.wildfly.plugins.wildfly-maven-plugin>
 
         <!-- keep this in sync with version that is used in arquillian -->


### PR DESCRIPTION
Improves error message when port is in use. Previous one was assuming that the server is running and managed containers by default should not connect to running instances. It might be however, that the default port 9990 is taken by some other process - for example [NVidia updater](http://in.relation.to/2016/07/28/how-to-fix-arquillian-and-nvidia-port-stealing-issue/) ;)

This pull request changes the error message with a bit more information of what might be happening.

As a bonus - update to latest Arquillian Core :)
