### PR TITLE
Adding "jboss.modules.system.pkgs" to embedded configuration.

### DIFF
--- a/container-embedded/src/main/java/org/jboss/as/arquillian/container/embedded/EmbeddedContainerConfiguration.java
+++ b/container-embedded/src/main/java/org/jboss/as/arquillian/container/embedded/EmbeddedContainerConfiguration.java
@@ -38,6 +38,8 @@ public class EmbeddedContainerConfiguration extends CommonContainerConfiguration
 
     private String serverConfig = System.getProperty("jboss.server.config.file.name");
 
+    private String systemPackages = System.getProperty("jboss.modules.system.pkgs");
+
     public EmbeddedContainerConfiguration() {
 
         // if no jbossHome is set use jboss.home of already running jvm
@@ -94,6 +96,18 @@ public class EmbeddedContainerConfiguration extends CommonContainerConfiguration
 
     public void setServerConfig(final String serverConfig) {
         this.serverConfig = serverConfig;
+    }
+
+    public String getSystemPackages() {
+        return systemPackages;
+    }
+
+    public void setSystemPackages(String systemPackages) {
+        this.systemPackages = systemPackages;
+    }
+
+    public String[] getSystemPackagesArray() {
+        return (systemPackages == null || systemPackages.isEmpty()) ? null : systemPackages.split(",");
     }
 
     /**

--- a/container-embedded/src/main/java/org/jboss/as/arquillian/container/embedded/EmbeddedDeployableContainer.java
+++ b/container-embedded/src/main/java/org/jboss/as/arquillian/container/embedded/EmbeddedDeployableContainer.java
@@ -46,7 +46,7 @@ public final class EmbeddedDeployableContainer extends CommonDeployableContainer
             SecurityActions.setSystemProperty(EmbeddedStandaloneServerFactory.JBOSS_EMBEDDED_ROOT, config.getCleanServerBaseDir());
         }
         final String[] cmdArgs = getCommandArgs(config);
-        server = EmbeddedProcessFactory.createStandaloneServer(config.getJbossHome(), config.getModulePath(), null, cmdArgs);
+        server = EmbeddedProcessFactory.createStandaloneServer(config.getJbossHome(), config.getModulePath(), config.getSystemPackagesArray(), cmdArgs);
     }
 
     @Override


### PR DESCRIPTION
I don't know exactly how to test if JBoss Modules is picking up "jboss.modules.system.pkgs", i tested just running with the coverage agent from IntelliJ IDEA. Before patching with this code, it was not possible, see here: https://stackoverflow.com/questions/37463876/coverage-integration-tests-intellij-on-wildfly
