### PR TITLE
[WFARQ-14] Introduce sanity check for container deployment count.

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
@@ -153,6 +153,10 @@ public class ServerSetupObserver {
             return;
         }
         int count = deployed.get(container.getName());
+        // this should never happen
+        if (count == 0) {
+            throw new RuntimeException("Deployment count on container " + container.getName() + " is negative; please check the test case for unexpected deploy / undeploy activity");
+        }
         deployed.put(container.getName(), --count);
         if (count == 0 && afterClassRun) {
             for (int i = setupTasksInForce.size() - 1; i >= 0; i--) {


### PR DESCRIPTION
See https://issues.jboss.org/browse/WFARQ-14

ServerSetupObserver depends on the fact that for every call to deploy there is a corresponding call to undeploy,  which means that that the deployment count for a container is zero or greater and will eventally return to zero by the end of a test. When the deployment count for a container goes below zero (for example, if deployments are manually controlled and the deployment logic is flawed), this can cause the entirely of the logic of ServerSetupObserver to break, and the incorrect state can get propagated across test cases in a test suite, making tracking down the error hard.

This issue adds a sanity check on container deployment counts which throws a RuntimeException if the count becomes negative. 