### PR TITLE
WFARQ-14 NPE in ServerSetupObserver.handleAfterUndeploy

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
@@ -152,7 +152,13 @@ public class ServerSetupObserver {
         if(deployed == null) {
             return;
         }
-        int count = deployed.get(container.getName());
+        Integer count = deployed.get(container.getName());
+        if (count == null) {
+            // The deployment was already undeployed or never deployed
+            // AfterUnDeploy and BeforeUnDeploy events are fired by arquillian-core regardless of deployment status
+            log.debugf("No deployments found for container %s.", container.getName());
+            return;
+        }
         deployed.put(container.getName(), --count);
         if (count == 0 && afterClassRun) {
             for (int i = setupTasksInForce.size() - 1; i >= 0; i--) {


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFARQ-14

* handleOnUndeploy not counting with the possibility of undeploy being fired by arq-core