### PR TITLE
WFARQ-16 ServerSetupObserver#handleAfterUndeploy() never tears down; …

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
@@ -140,12 +140,7 @@ public class ServerSetupObserver {
             }
         }
         afterClassRun = true;
-        if (deployed.isEmpty()) {
-            deployed = null;
-            setupTasksAll.clear();
-            setupTasksInForce.clear();
-            afterClassRun = false;
-        }
+        this.clear();
     }
 
     public synchronized void handleAfterUndeploy(@Observes AfterUnDeploy afterDeploy, final Container container) throws Exception {
@@ -154,7 +149,7 @@ public class ServerSetupObserver {
         }
         int count = deployed.get(container.getName());
         deployed.put(container.getName(), --count);
-        if (count == 0 && afterClassRun) {
+        if (count == 0 && !afterClassRun) {
             for (int i = setupTasksInForce.size() - 1; i >= 0; i--) {
                 try {
                     setupTasksInForce.get(i).tearDown(managementClient.get(), container.getName());
@@ -165,15 +160,17 @@ public class ServerSetupObserver {
             active.remove(container.getName());
             deployed.remove(container.getName());
         }
+        this.clear();
+    }
+
+    private void clear() {
         if (deployed.isEmpty()) {
             deployed = null;
             setupTasksAll.clear();
             setupTasksInForce.clear();
             afterClassRun = false;
         }
-
     }
-
 
     private static final class ContainerClassHolder {
         private final Class<?> testClass;


### PR DESCRIPTION
…never removes a deployment from its structure if it had no observer

Jira
https://issues.jboss.org/browse/WFARQ-16

Maybe this is intentional?

This currently fails 3 test cases:
1. testConfiguration(org.jboss.as.test.smoke.deployment.rar.tests.redeployment.ReDeploymentTestCase)  Time elapsed: 0.168 sec  <<< ERROR!
1. namedJdbcTest(org.jboss.as.test.integration.batch.deployment.DeploymentDescriptorTestCase)  Time elapsed: 0.132 sec  <<< FAILURE!
1. testSingleMethodAnnotationsUser1Template(org.jboss.as.test.integration.security.auditing.SecurityAuditingTestCase)  Time elapsed: 5.043 sec  <<< FAILURE!

which could be that the test cases are making assumptions; e.g. first one sets up only once but tears down twice.