### PR TITLE
WFARQ-16 ServerSetupObserver#afterTestClass() never clears internal m…

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
@@ -116,7 +116,7 @@ public class ServerSetupObserver {
     }
 
     public synchronized void afterTestClass(@Observes AfterClass afterClass) throws Exception {
-        if (setupTasksInForce.isEmpty()) {
+        if (deployed == null) {
             return;
         }
         //clean up if there are no more deployments on the server
@@ -134,9 +134,9 @@ public class ServerSetupObserver {
                             log.error("Setup task failed during tear down. Offending class '" + setupTasksAll.get(i) + "'", e);
                         }
                     }
-                    active.remove(container.getKey());
-                    it.remove();
                 }
+                active.remove(container.getKey());
+                it.remove();
             }
         }
         afterClassRun = true;


### PR DESCRIPTION
…aps if no server setup tasks were in place

https://issues.jboss.org/browse/WFARQ-16