### PR TITLE
[WFARQ-18] Clean up the ServerSetupObserver. Remove the multiple maps…

### DIFF
--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAfterClassTestCase.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAfterClassTestCase.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ServerSetupAfterClassTestCase extends TestOperations {
+    @ArquillianResource
+    private ManagementClient client;
+
+    @Deployment
+    public static JavaArchive deployment() {
+        // Create a dummy deployment so the client can be injected
+        return ShrinkWrap.create(JavaArchive.class).addManifest();
+    }
+
+    @Test
+    public void testSystemPropertyRemoved() throws Exception {
+        // All deployments from the ServerSetupDeploymentTestCase should have been undeployed and the
+        // ServerSetupTask.tearDown() should have been invoked
+        testSystemProperty(ServerSetupTestSuite.SYSTEM_PROPERTY_KEY);
+    }
+
+    @Override
+    ManagementClient getClient() {
+        return client;
+    }
+}

--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupDeploymentTestCase.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupDeploymentTestCase.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed;
+
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(ServerSetupDeploymentTestCase.SystemPropertySetupTask.class)
+@RunAsClient
+public class ServerSetupDeploymentTestCase extends TestOperations {
+
+    static class SystemPropertySetupTask implements ServerSetupTask {
+
+        private final ModelNode address = Operations.createAddress("system-property", ServerSetupTestSuite.SYSTEM_PROPERTY_KEY);
+
+        @Override
+        public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+            // Add a system property
+            final ModelNode op = Operations.createAddOperation(address);
+            op.get("value").set(ServerSetupTestSuite.SYSTEM_PROPERTY_VALUE);
+            final ModelNode result = managementClient.getControllerClient().execute(op);
+            if (!Operations.isSuccessfulOutcome(result)) {
+                throw new RuntimeException("Failed to add system property: " + Operations.getFailureDescription(result).asString());
+            }
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+            // Remove the system property
+            final ModelNode op = Operations.createRemoveOperation(address);
+            final ModelNode result = managementClient.getControllerClient().execute(op);
+            if (!Operations.isSuccessfulOutcome(result)) {
+                throw new RuntimeException("Failed to remove system property: " + Operations.getFailureDescription(result).asString());
+            }
+        }
+    }
+
+    private static final String DEPLOYMENT1 = "test-unmanaged-deployment-1.war";
+    private static final String DEPLOYMENT2 = "test-unmanaged-deployment-2.war";
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @ArquillianResource
+    protected ManagementClient client;
+
+
+    @Deployment(name = DEPLOYMENT1)
+    public static WebArchive createDeployment1() throws Exception {
+        return ShrinkWrap.create(WebArchive.class, DEPLOYMENT1)
+                .addClass(HelloWorldServlet.class);
+    }
+
+
+    @Deployment(managed = false, name = DEPLOYMENT2)
+    public static WebArchive createDeployment2() throws Exception {
+        return ShrinkWrap.create(WebArchive.class, DEPLOYMENT2)
+                .addClass(HelloWorldServlet.class);
+    }
+
+    @Test
+    public void testManualUndeploy() throws IOException {
+        // Undeploy the unmanaged deployment even though it's not deployed, this tests whether or not on the AfterClass
+        // listener the tear down will happen.
+        deployer.undeploy(DEPLOYMENT2);
+        // THe system property should still be there because the first deployment is still there
+        testSystemProperty(ServerSetupTestSuite.SYSTEM_PROPERTY_KEY, ServerSetupTestSuite.SYSTEM_PROPERTY_VALUE);
+        // Test leaving an unmanaged deployment deployed to ensure it will be undeployed
+        deployer.deploy(DEPLOYMENT2);
+    }
+
+    @Override
+    ManagementClient getClient() {
+        return client;
+    }
+}

--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupTestSuite.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupTestSuite.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Ensures the order of the tests to execute in the correct order.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        ServerSetupDeploymentTestCase.class,
+        ServerSetupAfterClassTestCase.class
+})
+public class ServerSetupTestSuite {
+    static final String SYSTEM_PROPERTY_KEY = "server.setup.key";
+    static final String SYSTEM_PROPERTY_VALUE = "server.setup.value";
+}

--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/TestOperations.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/TestOperations.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+abstract class TestOperations {
+
+    abstract ManagementClient getClient();
+
+    void testSystemProperty(final String key) throws IOException {
+        final ModelNode op = Operations.createOperation("read-children-names");
+        op.get("child-type").set("system-property");
+        final List<ModelNode> result = executeForSuccess(getClient(), op).asList();
+        for (ModelNode property : result) {
+            Assert.assertNotEquals(String.format("The key '%s' should have been removed from the server", key), key, property.asString());
+        }
+    }
+
+    void testSystemProperty(final String key, final String value) throws IOException {
+        final ModelNode address = Operations.createAddress("system-property", key);
+        final ModelNode result = executeForSuccess(getClient(), Operations.createReadResourceOperation(address));
+        Assert.assertEquals(value, result.get("value").asString());
+    }
+
+    static ModelNode executeForSuccess(final ManagementClient client, final ModelNode op) throws IOException {
+        final ModelNode result = client.getControllerClient().execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            throw new RuntimeException(String.format("Failed to executeForSuccess operation :%s%n%s", op, Operations.getFailureDescription(result).asString()));
+        }
+        return Operations.readResult(result);
+    }
+}

--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/UnmanagedDeploymentTestCase.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/UnmanagedDeploymentTestCase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests basic deployment
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(UnmanagedDeploymentTestCase.SystemPropertyServerSetup.class)
+@RunAsClient
+public class UnmanagedDeploymentTestCase extends TestOperations {
+
+    private static final String KEY = "test.property.key";
+    private static final String VALUE = "test-value";
+
+    static class SystemPropertyServerSetup implements ServerSetupTask {
+        private final ModelNode address = Operations.createAddress("system-property", KEY);
+
+        @Override
+        public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+            final ModelNode op = Operations.createAddOperation(address);
+            op.get("value").set(VALUE);
+            executeForSuccess(managementClient, op);
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+            executeForSuccess(managementClient, Operations.createRemoveOperation(address));
+        }
+    }
+
+    @ArquillianResource
+    private Deployer deployer;
+    @ArquillianResource
+    private ManagementClient client;
+
+    @Deployment(managed = false, name = "test-deployment")
+    public static JavaArchive create() {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "unmanaged-deployment-test.jar")
+                .addClass(SystemPropertyServiceActivator.class)
+                .addAsServiceProvider(ServiceActivator.class, SystemPropertyServiceActivator.class);
+        return archive;
+    }
+
+    @Test
+    @InSequence(1)
+    public void undeployFirst() throws Exception {
+        // Undeploy first which should not really do anything
+        deployer.undeploy("test-deployment");
+        // Now deploy the deployment which should execute the setup
+        deployer.deploy("test-deployment");
+        testSystemProperty(KEY, VALUE);
+
+    }
+
+    @Test
+    @InSequence(2)
+    public void contentDeployedThenUndeployed() throws Exception {
+        // After the undeploy, the tearDown() won't happen until the class is complete
+        deployer.undeploy("test-deployment");
+        testSystemProperty(KEY, VALUE);
+    }
+
+    @Override
+    ManagementClient getClient() {
+        return client;
+    }
+}


### PR DESCRIPTION
… and safely handle tear down failures if the ManagementClient has been closed, this would likely be due to the container being stopped.

@rhusar Would you mind giving this a review since you have looked at how this originally worked recently?