### PR TITLE
[WFARQ-20] Add Elytron support

### DIFF
--- a/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/CommonDomainContainerConfiguration.java
+++ b/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/CommonDomainContainerConfiguration.java
@@ -16,6 +16,7 @@
 package org.jboss.as.arquillian.container.domain;
 
 import java.net.InetAddress;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,11 +30,12 @@ import org.jboss.arquillian.container.spi.client.container.ContainerConfiguratio
  */
 public class CommonDomainContainerConfiguration implements ContainerConfiguration {
 
-    private InetAddress managementAddress;
+    private String managementAddress;
     private int managementPort;
 
     private String username;
     private String password;
+    private String wildflyConfig;
 
     private Map<String, String> containerNameMap;
 
@@ -44,16 +46,20 @@ public class CommonDomainContainerConfiguration implements ContainerConfiguratio
     private int serverOperationTimeoutInSeconds = 120;
 
     public CommonDomainContainerConfiguration() {
-        managementAddress = getInetAddress("127.0.0.1");
+        managementAddress = "127.0.0.1";
         managementPort = 9990 + Integer.decode(System.getProperty("jboss.socket.binding.port-offset", "0"));
     }
 
     public InetAddress getManagementAddress() {
+        return getInetAddress(managementAddress);
+    }
+
+    String getManagementHostName() {
         return managementAddress;
     }
 
     public void setManagementAddress(String host) {
-        this.managementAddress = getInetAddress(host);
+        this.managementAddress = host;
     }
 
     public int getManagementPort() {
@@ -152,6 +158,24 @@ public class CommonDomainContainerConfiguration implements ContainerConfiguratio
 
     public int getServerOperationTimeoutInSeconds() {
         return serverOperationTimeoutInSeconds;
+    }
+
+    /**
+     * The {@linkplain URI URI} path for the WildFly configuration.
+     *
+     * @return the URI for the path or {@code null} if no path was set
+     */
+    public String getWildflyConfig() {
+        return wildflyConfig;
+    }
+
+    /**
+     * Set the {@linkplain URI URI} path for the WildFly configuration.
+     *
+     * @param wildflyConfig the URI path
+     */
+    public void setWildflyConfig(final String wildflyConfig) {
+        this.wildflyConfig = wildflyConfig;
     }
 
     @Override

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -74,6 +74,18 @@
             <artifactId>shrinkwrap-descriptors-impl-base</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.client</groupId>
+            <artifactId>wildfly-client-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerConfiguration.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerConfiguration.java
@@ -15,6 +15,8 @@
  */
 package org.jboss.as.arquillian.container;
 
+import java.net.URI;
+
 import org.jboss.arquillian.container.spi.ConfigurationException;
 import org.jboss.arquillian.container.spi.client.container.ContainerConfiguration;
 
@@ -26,12 +28,13 @@ import org.jboss.arquillian.container.spi.client.container.ContainerConfiguratio
  */
 public class CommonContainerConfiguration implements ContainerConfiguration {
 
-    private String managementProtocol = "http-remoting";
+    private String managementProtocol = "remote+http";
     private String managementAddress;
     private int managementPort;
 
     private String username;
     private String password;
+    private String wildflyConfig;
 
     public CommonContainerConfiguration() {
         managementAddress = "127.0.0.1";
@@ -76,6 +79,24 @@ public class CommonContainerConfiguration implements ContainerConfiguration {
 
     public void setManagementProtocol(final String managementProtocol) {
         this.managementProtocol = managementProtocol;
+    }
+
+    /**
+     * The {@linkplain URI URI} path for the WildFly configuration.
+     *
+     * @return the URI for the path or {@code null} if no path was set
+     */
+    public String getWildflyConfig() {
+        return wildflyConfig;
+    }
+
+    /**
+     * Set the {@linkplain URI URI} path for the WildFly configuration.
+     *
+     * @param wildflyConfig the URI path
+     */
+    public void setWildflyConfig(final String wildflyConfig) {
+        this.wildflyConfig = wildflyConfig;
     }
 
     @Override

--- a/common/src/main/java/org/jboss/as/arquillian/container/ContextualJMXConnectorFactory.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ContextualJMXConnectorFactory.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container;
+
+import java.io.IOException;
+import java.util.Map;
+import javax.management.ListenerNotFoundException;
+import javax.management.MBeanServerConnection;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import javax.security.auth.Subject;
+
+import org.wildfly.common.context.Contextual;
+import org.wildfly.common.function.ExceptionFunction;
+
+/**
+ * A {@link JMXConnector} which wraps invocations of the delegate client in the provided
+ * {@linkplain Contextual context}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class ContextualJMXConnectorFactory {
+
+    private ContextualJMXConnectorFactory() {
+    }
+
+    /**
+     * Creates and connects a new connector.
+     * <p>
+     * The {@link JMXConnectorFactory#connect(JMXServiceURL)} is invoked with the {@code context} parameter. The
+     * parameter is then used to create a new {@link ContextualJMXConnectorFactory}.
+     * </p>
+     *
+     * @param context the context to use
+     * @param url     the JMX URL
+     * @param env     the environment
+     *
+     * @return a new JMX connector
+     *
+     * @throws IOException if the connector client or the connection cannot be made because of a communication problem
+     */
+    @SuppressWarnings("StaticMethodOnlyUsedInOneClass")
+    static JMXConnector connect(final Contextual<?> context, final JMXServiceURL url, final Map<String, Object> env) throws IOException {
+        if (context == null) {
+            return JMXConnectorFactory.connect(url, env);
+        }
+        return context.runExFunction((ExceptionFunction<Object, JMXConnector, IOException>) o ->
+                new ContextualJMXConnector(context, JMXConnectorFactory.connect(url, env)), null);
+    }
+
+    private static class ContextualJMXConnector implements JMXConnector {
+        private final Contextual<?> context;
+        private final JMXConnector delegate;
+
+        private ContextualJMXConnector(final Contextual<?> context, final JMXConnector delegate) {
+            this.context = context;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void connect() throws IOException {
+            context.runExConsumer(o -> delegate.connect(), null);
+        }
+
+        @Override
+        public void connect(final Map<String, ?> env) throws IOException {
+            context.runExConsumer(o -> delegate.connect(env), null);
+        }
+
+        @Override
+        public MBeanServerConnection getMBeanServerConnection() throws IOException {
+            return context.runExFunction(o -> delegate.getMBeanServerConnection(), null);
+        }
+
+        @Override
+        public MBeanServerConnection getMBeanServerConnection(final Subject delegationSubject) throws IOException {
+            return context.runExFunction(o -> delegate.getMBeanServerConnection(delegationSubject), null);
+        }
+
+        @Override
+        public void close() throws IOException {
+            context.runExConsumer(o -> delegate.close(), null);
+        }
+
+        @Override
+        public void addConnectionNotificationListener(final NotificationListener listener, final NotificationFilter filter, final Object handback) {
+            context.runExConsumer(o -> delegate.addConnectionNotificationListener(listener, filter, handback), null);
+        }
+
+        @Override
+        public void removeConnectionNotificationListener(final NotificationListener listener) throws ListenerNotFoundException {
+            context.runExConsumer(o -> delegate.removeConnectionNotificationListener(listener), null);
+        }
+
+        @Override
+        public void removeConnectionNotificationListener(final NotificationListener l, final NotificationFilter f, final Object handback) throws ListenerNotFoundException {
+            context.runExConsumer(o -> delegate.removeConnectionNotificationListener(l, f, handback), null);
+        }
+
+        @Override
+        public String getConnectionId() throws IOException {
+            return context.runExFunction(o -> delegate.getConnectionId(), null);
+        }
+    }
+}

--- a/container-managed-domain/pom.xml
+++ b/container-managed-domain/pom.xml
@@ -31,6 +31,11 @@
 
     <packaging>jar</packaging>
 
+    <properties>
+        <maven.test.skip>false</maven.test.skip>
+        <skipTests>${maven.test.skip}</skipTests>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
@@ -107,6 +112,10 @@
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Don't execute if we're skipping tests -->
+                    <skip>${skipTests}</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <id>fix-servlet</id>

--- a/integration-tests/elytron/domain/pom.xml
+++ b/integration-tests/elytron/domain/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>elytron</artifactId>
+        <groupId>org.wildfly.arquillian</groupId>
+        <version>2.1.0.Alpha2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>elytron-domain</artifactId>
+    <name>WildFly: Arquillian Elytron Domain Integration Tests</name>
+
+    <dependencies>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.protocol</groupId>
+            <artifactId>arquillian-protocol-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-domain-managed</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.build</groupId>
+                <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <jboss.home>${jboss.home}</jboss.home>
+                        <wildfly.config>${project.baseUri}/src/test/resources/elytron-wildfly-config.xml</wildfly.config>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <offline>true</offline>
+                    <jboss-home>${jboss.home}</jboss-home>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>configure-elytron</id>
+                        <goals>
+                            <goal>execute-commands</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                        <configuration>
+                            <stdout>${project.basedir}/target/config.log</stdout>
+                            <commands>
+                                <command>embed-host-controller</command>
+                                <command>/host=master/subsystem=elytron/filesystem-realm=testRealm:add(path=fs-realm-users,relative-to=jboss.domain.config.dir)</command>
+                                <command>/host=master/subsystem=elytron/filesystem-realm=testRealm/identity=test-admin:add()</command>
+                                <command>/host=master/subsystem=elytron/filesystem-realm=testRealm/identity=test-admin:set-password(clear={password="admin.12345"})</command>
+                                <command>/host=master/subsystem=elytron/security-domain=testSecurityDomain:add(realms=[{realm=testRealm}],default-realm=testRealm,permission-mapper=default-permission-mapper)</command>
+                                <command>/host=master/subsystem=elytron/sasl-authentication-factory=test-sasl-auth:add(sasl-server-factory=configured,security-domain=testSecurityDomain,mechanism-configurations=[{mechanism-name=DIGEST-MD5,mechanism-realm-configurations=[{realm-name=testRealm}]}])</command>
+                                <command>/host=master/core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade.sasl-authentication-factory, value=test-sasl-auth)</command>
+                                <command>stop-embedded-host-controller</command>
+                            </commands>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/integration-tests/elytron/domain/src/test/java/org/wildfly/arquillian/integration/test/domain/ElytronIntegrationTestCase.java
+++ b/integration-tests/elytron/domain/src/test/java/org/wildfly/arquillian/integration/test/domain/ElytronIntegrationTestCase.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.domain;
+
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.domain.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.arquillian.domain.api.TargetsServerGroup;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+public class ElytronIntegrationTestCase {
+
+    @Deployment
+    @TargetsServerGroup("main-server-group")
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.as.controller\n"), "META-INF/MANIFEST.MF");
+    }
+
+    @Test
+    @RunAsClient
+    public void testClientUser(@ArquillianResource ManagementClient client) throws IOException {
+        final ModelNode result = client.getControllerClient().execute(Operations.createOperation("whoami"));
+        Assert.assertTrue(Operations.isSuccessfulOutcome(result));
+        final ModelNode identity = Operations.readResult(result);
+        Assert.assertEquals("Expected the connected user to be test-admin", "test-admin", identity.get("identity", "username").asString());
+    }
+
+    @Test
+    @TargetsServerGroup("main-server-group")
+    @Ignore("Currently domain does not allow injecting clients into in container tests")
+    public void testInContainerClientUser(@ArquillianResource ManagementClient client) throws IOException {
+        final ModelNode result = client.getControllerClient().execute(Operations.createOperation("whoami"));
+        Assert.assertTrue(Operations.isSuccessfulOutcome(result));
+        final ModelNode identity = Operations.readResult(result);
+        Assert.assertEquals("Expected the connected user to be test-admin", "test-admin", identity.get("identity", "username").asString());
+    }
+}

--- a/integration-tests/elytron/domain/src/test/resources/arquillian.xml
+++ b/integration-tests/elytron/domain/src/test/resources/arquillian.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="jboss" default="true">
+        <configuration>
+            <property name="jbossHome">${jboss.home}</property>
+            <property name="wildflyConfig">${wildfly.config}</property>
+            <property name="allowConnectingToRunningServer">false</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/integration-tests/elytron/domain/src/test/resources/elytron-wildfly-config.xml
+++ b/integration-tests/elytron/domain/src/test/resources/elytron-wildfly-config.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+    <authentication-client xmlns="urn:elytron:1.0">
+        <authentication-rules>
+            <rule use-configuration="arq-login">
+            </rule>
+        </authentication-rules>
+        <authentication-configurations>
+            <configuration name="arq-login">
+                <allow-sasl-mechanisms names="DIGEST-MD5" />
+                <use-service-loader-providers />
+                <set-user-name name="test-admin" />
+                <credentials>
+                    <clear-password password="admin.12345" />
+                </credentials>
+                <set-mechanism-realm name="testRealm" />
+            </configuration>
+        </authentication-configurations>
+    </authentication-client>
+</configuration>

--- a/integration-tests/elytron/pom.xml
+++ b/integration-tests/elytron/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.wildfly.arquillian</groupId>
+        <artifactId>integration-tests</artifactId>
+        <version>2.1.0.Alpha2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>elytron</artifactId>
+    <name>WildFly: Arquillian Elytron Integration Tests</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>standalone</module>
+        <module>domain</module>
+    </modules>
+</project>

--- a/integration-tests/elytron/server-provisioning.xml
+++ b/integration-tests/elytron/server-provisioning.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright 2015 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" copy-module-artifacts="false">
+    <feature-packs>
+        <feature-pack groupId="${org.wildfly.groupId}" artifactId="${org.wildfly.artifactId}" version="${org.wildfly.version}" />
+    </feature-packs>
+</server-provisioning>

--- a/integration-tests/elytron/standalone/pom.xml
+++ b/integration-tests/elytron/standalone/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.wildfly.arquillian</groupId>
+        <artifactId>elytron</artifactId>
+        <version>2.1.0.Alpha2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>elytron-standalone</artifactId>
+    <name>WildFly: Arquillian Elytron Standalone Integration Tests</name>
+
+    <dependencies>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.protocol</groupId>
+            <artifactId>arquillian-protocol-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-managed</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.build</groupId>
+                <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <jboss.home>${jboss.home}</jboss.home>
+                        <wildfly.config>${project.baseUri}/src/test/resources/elytron-wildfly-config.xml</wildfly.config>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <offline>true</offline>
+                    <jboss-home>${jboss.home}</jboss-home>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>configure-elytron</id>
+                        <goals>
+                            <goal>execute-commands</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                        <configuration>
+                            <stdout>${project.basedir}/target/config.log</stdout>
+                            <commands>
+                                <command>embed-server</command>
+                                <command>/subsystem=elytron/filesystem-realm=testRealm:add(path=fs-realm-users,relative-to=jboss.server.config.dir)</command>
+                                <command>/subsystem=elytron/filesystem-realm=testRealm/identity=test-admin:add()</command>
+                                <command>/subsystem=elytron/filesystem-realm=testRealm/identity=test-admin:set-password(clear={password="admin.12345"})</command>
+                                <command>/subsystem=elytron/security-domain=testSecurityDomain:add(realms=[{realm=testRealm}],default-realm=testRealm,permission-mapper=default-permission-mapper)</command>
+                                <command>/subsystem=elytron/sasl-authentication-factory=test-sasl-auth:add(sasl-server-factory=configured,security-domain=testSecurityDomain,mechanism-configurations=[{mechanism-name=DIGEST-MD5,mechanism-realm-configurations=[{realm-name=testRealm}]}])</command>
+                                <command>/core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade.sasl-authentication-factory, value=test-sasl-auth)</command>
+                                <command>stop-embedded-server</command>
+                            </commands>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/integration-tests/elytron/standalone/src/test/java/org/wildfly/arquillian/integration/test/standalone/ElytronIntegrationTestCase.java
+++ b/integration-tests/elytron/standalone/src/test/java/org/wildfly/arquillian/integration/test/standalone/ElytronIntegrationTestCase.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.standalone;
+
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+public class ElytronIntegrationTestCase {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.as.controller\n"), "META-INF/MANIFEST.MF");
+    }
+
+    @Test
+    @RunAsClient
+    public void testClientUser(@ArquillianResource ManagementClient client) throws IOException {
+        final ModelNode result = client.getControllerClient().execute(Operations.createOperation("whoami"));
+        Assert.assertTrue(Operations.isSuccessfulOutcome(result));
+        final ModelNode identity = Operations.readResult(result);
+        Assert.assertEquals("Expected the connected user to be test-admin", "test-admin", identity.get("identity", "username").asString());
+    }
+
+    @Test
+    public void testInContainerClientUser(@ArquillianResource ManagementClient client) throws IOException {
+        final ModelNode result = client.getControllerClient().execute(Operations.createOperation("whoami"));
+        Assert.assertTrue(Operations.isSuccessfulOutcome(result));
+        final ModelNode identity = Operations.readResult(result);
+        Assert.assertEquals("Expected the connected user to be test-admin", "test-admin", identity.get("identity", "username").asString());
+    }
+}

--- a/integration-tests/elytron/standalone/src/test/resources/arquillian.xml
+++ b/integration-tests/elytron/standalone/src/test/resources/arquillian.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <defaultProtocol type="jmx-as7"/>
+
+    <container qualifier="jboss" default="true">
+        <configuration>
+            <property name="jbossHome">${jboss.home}</property>
+            <property name="wildflyConfig">${wildfly.config}</property>
+            <property name="allowConnectingToRunningServer">false</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/integration-tests/elytron/standalone/src/test/resources/elytron-wildfly-config.xml
+++ b/integration-tests/elytron/standalone/src/test/resources/elytron-wildfly-config.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+    <authentication-client xmlns="urn:elytron:1.0">
+        <authentication-rules>
+            <rule use-configuration="arq-login">
+            </rule>
+        </authentication-rules>
+        <authentication-configurations>
+            <configuration name="arq-login">
+                <allow-sasl-mechanisms names="DIGEST-MD5" />
+                <use-service-loader-providers />
+                <set-user-name name="test-admin" />
+                <credentials>
+                    <clear-password password="admin.12345" />
+                </credentials>
+                <set-mechanism-realm name="testRealm" />
+            </configuration>
+        </authentication-configurations>
+    </authentication-client>
+</configuration>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.wildfly.arquillian</groupId>
+        <artifactId>wildfly-arquillian-parent</artifactId>
+        <version>2.1.0.Alpha2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>integration-tests</artifactId>
+    <name>WildFly: Arquillian Integration Tests</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>elytron</module>
+    </modules>
+
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <version.org.jboss.arquillian.core>1.1.12.Final</version.org.jboss.arquillian.core>
         <version.org.wildfly.client.wildfly-client-config>1.0.0.Beta1</version.org.wildfly.client.wildfly-client-config>
         <version.org.wildfly.common.wildfly-common>1.2.0.Beta5</version.org.wildfly.common.wildfly-common>
-        <version.org.wildfly.plugins.wildfly-maven-plugin>1.2.0.Alpha1</version.org.wildfly.plugins.wildfly-maven-plugin>
+        <version.org.wildfly.plugins.wildfly-maven-plugin>1.2.0.Alpha4</version.org.wildfly.plugins.wildfly-maven-plugin>
         <version.org.wildfly.security.wildfly-elytron>1.1.0.Beta33</version.org.wildfly.security.wildfly-elytron>
 
         <!-- keep this in sync with version that is used in arquillian -->
@@ -160,6 +160,7 @@
         <module>common-domain</module>
         <module>container-remote-domain</module>
         <module>container-managed-domain</module>
+        <module>integration-tests</module>
     </modules>
 
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,14 @@
     <name>WildFly: Arquillian</name>
 
     <properties>
-        <version.org.wildfly.core>3.0.0.Alpha19</version.org.wildfly.core>
-        <version.org.wildfly.full>10.0.0.Final</version.org.wildfly.full>
+        <version.org.wildfly.core>3.0.0.Beta11</version.org.wildfly.core>
+        <version.org.wildfly.full>11.0.0.Alpha1</version.org.wildfly.full>
         <version.junit>4.12</version.junit>
         <version.org.jboss.arquillian.core>1.1.12.Final</version.org.jboss.arquillian.core>
-        <version.org.wildfly.plugins.wildfly-maven-plugin>1.1.0.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
+        <version.org.wildfly.client.wildfly-client-config>1.0.0.Beta1</version.org.wildfly.client.wildfly-client-config>
+        <version.org.wildfly.common.wildfly-common>1.2.0.Beta5</version.org.wildfly.common.wildfly-common>
+        <version.org.wildfly.plugins.wildfly-maven-plugin>1.2.0.Alpha1</version.org.wildfly.plugins.wildfly-maven-plugin>
+        <version.org.wildfly.security.wildfly-elytron>1.1.0.Beta33</version.org.wildfly.security.wildfly-elytron>
 
         <!-- keep this in sync with version that is used in arquillian -->
         <version.org.jboss.shrinkwrap.descriptors>2.0.0-alpha-10</version.org.jboss.shrinkwrap.descriptors>
@@ -217,6 +220,17 @@
             </dependency>
 
             <!-- External dependencies -->
+            <dependency>
+                <groupId>org.wildfly.client</groupId>
+                <artifactId>wildfly-client-config</artifactId>
+                <version>${version.org.wildfly.client.wildfly-client-config}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.common</groupId>
+                <artifactId>wildfly-common</artifactId>
+                <version>${version.org.wildfly.common.wildfly-common}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.wildfly.core</groupId>
@@ -256,6 +270,12 @@
                 <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-launcher</artifactId>
                 <version>${version.org.wildfly.core}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron</artifactId>
+                <version>${version.org.wildfly.security.wildfly-elytron}</version>
             </dependency>
 
             <dependency>

--- a/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/ArquillianServiceDeployer.java
+++ b/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/ArquillianServiceDeployer.java
@@ -66,6 +66,7 @@ public class ArquillianServiceDeployer {
                 out.writeObject(props.get("managementPort"));
                 out.writeObject(NetworkUtils.formatPossibleIpv6Address(props.get("managementAddress")));
                 out.writeObject(NetworkUtils.formatPossibleIpv6Address(props.get("managementProtocol")));
+                out.writeObject(props.get("wildflyConfig"));
                 out.close();
                 serviceArchive.addAsManifestResource(new ByteArrayAsset(bytes.toByteArray()), "org.jboss.as.managementConnectionProps");
 

--- a/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/JMXProtocolPackager.java
+++ b/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/JMXProtocolPackager.java
@@ -65,6 +65,7 @@ import org.jboss.shrinkwrap.api.container.ManifestContainer;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
+import org.wildfly.plugin.core.ContextualModelControllerClient;
 
 /**
  * A {@link DeploymentPackager} for the JMXProtocol.
@@ -140,6 +141,10 @@ public class JMXProtocolPackager implements DeploymentPackager {
         archiveDependencies.add(ModuleIdentifier.create("org.jboss.dmr"));
         archiveDependencies.add(ModuleIdentifier.create("org.jboss.msc"));
         archiveDependencies.add(ModuleIdentifier.create("org.wildfly.security.manager"));
+        archiveDependencies.add(ModuleIdentifier.create("org.wildfly.common"));
+        archiveDependencies.add(ModuleIdentifier.create("org.wildfly.client.config"));
+        archiveDependencies.add(ModuleIdentifier.create("org.wildfly.security.elytron"));
+        archive.addClass(ContextualModelControllerClient.class);
 
         // Merge the auxiliary archives and collect the loadable extensions
         final Set<String> loadableExtensions = new HashSet<String>();


### PR DESCRIPTION
First commit adds the Elytron support. 

Second commit adds some tests for the Elytron support. These tests aren't required and they do add a new integration-tests Maven module. I'm not sure if we should do this or not, but there have been times where integration tests would likely catch some errors.