### PR TITLE
Now overriding ip from arquillian.xml if your server is binded to 0.0.0.0

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
@@ -334,7 +334,7 @@ public class ManagementClient implements Closeable {
             operation.get("include-runtime").set(true);
             ModelNode binding = executeForResult(operation);
             String ip = binding.get("bound-address").asString();
-            ip = formatIP(ip);
+            ip = formatIP(ip, mgmtAddress);
 
             final int port = defined(binding.get("bound-port"), socketBindingGroupName + " -> " + socketBinding + " -> bound-port is undefined").asInt();
 
@@ -344,14 +344,19 @@ public class ManagementClient implements Closeable {
         }
     }
 
-    static String formatIP(String ip) {
+    static String formatIP(String ip, String mgmtAddress) {
         //it appears some system can return a binding with the zone specifier on the end
         if (ip.contains(":") && ip.contains("%")) {
             ip = ip.split("%")[0];
         }
         if (ip.equals("0.0.0.0")) {
-            logger.debug("WildFly is bound to 0.0.0.0 which is correct, setting client to 127.0.0.1");
-            ip = "127.0.0.1";
+            if (mgmtAddress != null && !mgmtAddress.trim().isEmpty()) {
+                logger.debug("WildFly is bound to 0.0.0.0 which is correct, setting configuration from arquillian.xml,  setting client to " + mgmtAddress);
+                ip = mgmtAddress;
+            } else {
+                logger.debug("WildFly is bound to 0.0.0.0 which is correct, setting client to 127.0.0.1");
+                ip = "127.0.0.1";
+            }
         }
         return ip;
     }

--- a/common/src/test/java/org/jboss/as/arquillian/container/ManagementClientTest.java
+++ b/common/src/test/java/org/jboss/as/arquillian/container/ManagementClientTest.java
@@ -24,14 +24,32 @@ public class ManagementClientTest {
     @Test
     public void shouldParseBindAllAsLocalhost() {
         String sourceIp = "0.0.0.0";
-        String parsedIp = ManagementClient.formatIP(sourceIp);
+        String parsedIp = ManagementClient.formatIP(sourceIp, null);
+
         Assert.assertEquals("127.0.0.1", parsedIp);
     }
 
     @Test
-    public void shouldParseLocalIPAsNormalIP() {
+    public void shouldParseLocalIPAsNormalIPWhenNoMgmtAddress() {
         String sourceIp = "10.1.2.3";
-        String formattedIp = ManagementClient.formatIP(sourceIp);
+        String formattedIp = ManagementClient.formatIP(sourceIp, null);
+
         Assert.assertEquals(sourceIp, formattedIp);
+    }
+
+    @Test
+    public void shouldParseMgmtAddressAsNormalIP() {
+        String mgmtIp = "10.1.2.3";
+        String formattedIp = ManagementClient.formatIP("0.0.0.0", mgmtIp);
+
+        Assert.assertEquals(mgmtIp, formattedIp);
+    }
+
+    @Test
+    public void shouldParseMgmtAddressAsNormalIPIfSourceAndMgmtAddressAreSame() {
+        String ip = "0.0.0.0";
+        String formattedIp = ManagementClient.formatIP(ip, ip);
+
+        Assert.assertEquals(ip, formattedIp);
     }
 }


### PR DESCRIPTION
Fixes https://issues.jboss.org/browse/WFARQ-30

Details:
If user started wildfly binded to `0.0.0.0` & tried to run tests as `@RunAsClient`, `@ArquillianResource` is resolving to localhost i.e. `127.0.0.1`.

This PR fixes above issue. Run test with following configuration in arquillian.xml:
``` 
<container qualifier="remote-container" default="true">
    <configuration>
      <!--this is required only if you want to run against remote server i.e. 10.209.69.207 -->
      <!--<property name="managementAddress">your-remote-ip</property>-->
      <property name="managementAddress">10.70.1.162</property>
      <property name="managementPort">9991</property>
      <property name="username">admin#123</property>
      <property name="password">#12AdmFoo!</property>
    </configuration>
  </container>
```
