### PR TITLE
Overriding property `host` & `port` from arquillian configuration if wildfly is binded to 0.0.0.0

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerConfiguration.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerConfiguration.java
@@ -35,10 +35,14 @@ public class CommonContainerConfiguration implements ContainerConfiguration {
     private String username;
     private String password;
     private String wildflyConfig;
+    private String host;
+    private int port;
 
     public CommonContainerConfiguration() {
         managementAddress = "127.0.0.1";
         managementPort = 9990 + Integer.decode(System.getProperty("jboss.socket.binding.port-offset", "0"));
+        host = null;
+        port = -1;
     }
 
     public String getManagementAddress() {
@@ -75,6 +79,22 @@ public class CommonContainerConfiguration implements ContainerConfiguration {
 
     public String getManagementProtocol() {
         return managementProtocol;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
     }
 
     public void setManagementProtocol(final String managementProtocol) {

--- a/common/src/main/java/org/jboss/as/arquillian/container/CommonDeployableContainer.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/CommonDeployableContainer.java
@@ -97,8 +97,7 @@ public abstract class CommonDeployableContainer<T extends CommonContainerConfigu
             }
         }
 
-        final ManagementClient client = new ManagementClient(new DelegatingModelControllerClient(mccProvider),
-                containerConfig.getManagementAddress(), containerConfig.getManagementPort(), containerConfig.getManagementProtocol(), authenticationContext);
+        final ManagementClient client = new ManagementClient(new DelegatingModelControllerClient(mccProvider), authenticationContext, containerConfig);
         managementClient.set(client);
 
         archiveDeployer.set(new ArchiveDeployer(client));


### PR DESCRIPTION
Fixes https://issues.jboss.org/browse/WFARQ-30

Now you can use following configuration in arquillian.xml to override host if wildfly is binded to `0.0.0.0` so you can run test as `@RunAsClient`

```xml
  <container qualifier="remote-container" default="true">
    <configuration>
      <property name="managementPort">9991</property>
      <property name="host">192.168.165.37</property>
      <property name="port">8097</property>
    </configuration>

  </container>
```