### PR TITLE
[WFARQ-38] Only attempt to read the undertow subsystem on the deploym…

### DIFF
--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientEnterpriseArchiveServletTestCase.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientEnterpriseArchiveServletTestCase.java
@@ -42,9 +42,11 @@ import org.junit.runner.RunWith;
 @RunAsClient
 public class ManagedAsClientEnterpriseArchiveServletTestCase {
 
+    private static final String CONTEXT_NAME = "test-hello-world";
+
     @Deployment(testable = false)
     public static EnterpriseArchive createDeployment() throws Exception {
-        WebArchive war = ShrinkWrap.create(WebArchive.class).addClass(HelloWorldServlet.class);
+        WebArchive war = ShrinkWrap.create(WebArchive.class,  CONTEXT_NAME + ".war").addClass(HelloWorldServlet.class);
         return ShrinkWrap.create(EnterpriseArchive.class).addAsModule(war);
     }
 
@@ -57,6 +59,12 @@ public class ManagedAsClientEnterpriseArchiveServletTestCase {
         Assert.assertNotNull(deploymentUrl);
         String result = getContent(new URL(deploymentUrl.toString() + HelloWorldServlet.URL_PATTERN.substring(1)));
         Assert.assertEquals(HelloWorldServlet.GREETING, result);
+    }
+
+    @Test
+    public void testWebContext() {
+        Assert.assertTrue(String.format("Expected context to start with /%s, but found %s", CONTEXT_NAME, deploymentUrl.getPath()),
+                deploymentUrl.getPath().startsWith("/" + CONTEXT_NAME));
     }
 
     private String getContent(URL url) throws Exception {

--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientWebArchiveServletTestCase.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientWebArchiveServletTestCase.java
@@ -64,6 +64,12 @@ public class ManagedAsClientWebArchiveServletTestCase {
         Assert.assertEquals(HelloWorldServlet.GREETING, result);
     }
 
+    @Test
+    public void testWebContext() {
+        Assert.assertTrue(String.format("Expected context to start with /%s but found %s", CONTEXT_NAME, deploymentUrl.getPath()),
+                deploymentUrl.getPath().startsWith("/" + CONTEXT_NAME));
+    }
+
     private String getContent(URL url) throws Exception {
         InputStream is = url.openStream();
         ByteArrayOutputStream out = new ByteArrayOutputStream();


### PR DESCRIPTION
…ent resource to find the web context.

https://issues.jboss.org/browse/WFARQ-38

The main reason for this is for a workaround for https://issues.jboss.org/browse/WFLY-9752. However reading the undertow resource directly can cause issues with singleton deployments where the node might not be started yet.