### PR TITLE
[WFARQ-39] catching AssertionError from SetupTask.tearDown

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
@@ -198,7 +198,7 @@ public class ServerSetupObserver {
                 while ((task = setupTasks.pollLast()) != null) {
                     try {
                         task.tearDown(client, containerName);
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         log.errorf(e, "Setup task failed during tear down. Offending class '%s'", task);
                     }
                 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFARQ-39

Resolves problem when failed tearDown causes following unrelated testcase failure.

When management operation in tearDown fails, AssertionError is thrown, but ServerSetupObserver catch only Exceptions - processing of setup tasks of following test is skipped and unrelated test fails.