### PR TITLE
Set JBOSS_HOME environment variable

### DIFF
--- a/container-embedded/pom.xml
+++ b/container-embedded/pom.xml
@@ -88,6 +88,9 @@
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <jboss.home>${jboss.home}</jboss.home>
                     </systemPropertyVariables>
+                    <environmentVariables>
+                        <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                    </environmentVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/container-managed-domain/pom.xml
+++ b/container-managed-domain/pom.xml
@@ -89,6 +89,9 @@
                             <systemPropertyVariables>
                                 <jboss.home>${jboss.home}</jboss.home>
                             </systemPropertyVariables>
+                            <environmentVariables>
+                                <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                            </environmentVariables>
                         </configuration>
                     </execution>
                     <execution>
@@ -104,6 +107,9 @@
                                 <arquillian.xml>manual-arquillian.xml</arquillian.xml>
                                 <jboss.home>${jboss.home}</jboss.home>
                             </systemPropertyVariables>
+                            <environmentVariables>
+                                <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                            </environmentVariables>
                         </configuration>
                     </execution>
                 </executions>

--- a/container-managed/pom.xml
+++ b/container-managed/pom.xml
@@ -141,6 +141,9 @@
                             <systemPropertyVariables>
                                 <jboss.home>${jboss.home}</jboss.home>
                             </systemPropertyVariables>
+                            <environmentVariables>
+                                <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                            </environmentVariables>
                         </configuration>
                     </execution>
                     <execution>
@@ -156,6 +159,9 @@
                                 <arquillian.xml>manual-arquillian.xml</arquillian.xml>
                                 <jboss.home>${jboss.home}</jboss.home>
                             </systemPropertyVariables>
+                            <environmentVariables>
+                                <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                            </environmentVariables>
                         </configuration>
                     </execution>
                 </executions>

--- a/integration-tests/elytron/domain/pom.xml
+++ b/integration-tests/elytron/domain/pom.xml
@@ -77,6 +77,9 @@
                         <jboss.home>${jboss.home}</jboss.home>
                         <wildfly.config>${project.baseUri}/src/test/resources/elytron-wildfly-config.xml</wildfly.config>
                     </systemPropertyVariables>
+                    <environmentVariables>
+                        <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                    </environmentVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-tests/elytron/standalone/pom.xml
+++ b/integration-tests/elytron/standalone/pom.xml
@@ -78,6 +78,9 @@
                         <jboss.home>${jboss.home}</jboss.home>
                         <wildfly.config>${project.baseUri}/src/test/resources/elytron-wildfly-config.xml</wildfly.config>
                     </systemPropertyVariables>
+                    <environmentVariables>
+                        <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                    </environmentVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/testng-integration/pom.xml
+++ b/testng-integration/pom.xml
@@ -78,6 +78,9 @@
                     <systemPropertyVariables>
                         <jboss.home>${jboss.home}</jboss.home>
                     </systemPropertyVariables>
+                    <environmentVariables>
+                        <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
+                    </environmentVariables>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
I encountered some issues running the tests on a development system where the `JBOSS_HOME` environment variable was set to a local installation of WildFly running at an other version. As the tests are ran against a local JBOSS_HOME anyway, it probably makes sense to override any present  `JBOSS_HOME` variable with the provided folder for the tests.