### PR TITLE
Switch to WildFly 12, #131

### DIFF
--- a/container-managed-domain/pom.xml
+++ b/container-managed-domain/pom.xml
@@ -108,36 +108,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Workaround for WFLY-6201 to allow tests to run with the servlet container only -->
-            <plugin>
-                <groupId>org.wildfly.plugins</groupId>
-                <artifactId>wildfly-maven-plugin</artifactId>
-                <configuration>
-                    <!-- Don't execute if we're skipping tests -->
-                    <skip>${skipTests}</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>fix-servlet</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>execute-commands</goal>
-                        </goals>
-                        <configuration>
-                            <offline>true</offline>
-                            <jboss-home>${jboss.home}</jboss-home>
-                            <execute-commands>
-                                <fail-on-error>false</fail-on-error>
-                                <commands>
-                                    <command>embed-host-controller</command>
-                                    <command>/server-group=other-server-group:add(socket-binding-group=standard-sockets, profile=default)</command>
-                                    <command>stop-embedded-host-controller</command>
-                                </commands>
-                            </execute-commands>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
     <name>WildFly: Arquillian</name>
 
     <properties>
-        <version.org.wildfly.core>3.0.9.Final</version.org.wildfly.core>
-        <version.org.wildfly.full>10.0.0.Final</version.org.wildfly.full>
+        <version.org.wildfly.core>4.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.full>12.0.0.Final</version.org.wildfly.full>
         <version.junit>4.12</version.junit>
         <version.org.jboss.arquillian.core>1.2.1.Final</version.org.jboss.arquillian.core>
         <version.org.wildfly.common.wildfly-common>1.3.0.Final</version.org.wildfly.common.wildfly-common>


### PR DESCRIPTION
Pull request that bumps the versions for WildFly full to 12.0.0.0.Final and WildFly core to 4.0.0.Final. As the workaround for WFLY-6201 is not necessary anymore, this change has been reverted.