### PR TITLE
[WFARQ-43] Upgrade WildFly Core to 5.0.0.Alpha6. Added optional java.…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <name>WildFly: Arquillian</name>
 
     <properties>
-        <version.org.wildfly.core>4.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>5.0.0.Alpha7</version.org.wildfly.core>
         <version.org.wildfly.full>10.0.0.Final</version.org.wildfly.full>
         <version.junit>4.12</version.junit>
         <version.org.jboss.arquillian.core>1.2.1.Final</version.org.jboss.arquillian.core>

--- a/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/JMXProtocolPackager.java
+++ b/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/JMXProtocolPackager.java
@@ -88,6 +88,7 @@ public class JMXProtocolPackager implements DeploymentPackager {
         defaultDependencies.add("org.jboss.modules");
         defaultDependencies.add("org.jboss.msc");
         defaultDependencies.add("org.wildfly.security.manager");
+        optionalDeps.add("java.logging");
     }
 
     private static final Logger log = Logger.getLogger(JMXProtocolPackager.class);
@@ -142,6 +143,7 @@ public class JMXProtocolPackager implements DeploymentPackager {
         archiveDependencies.add(ModuleIdentifier.create("org.wildfly.security.manager"));
         archiveDependencies.add(ModuleIdentifier.create("org.wildfly.common"));
         archiveDependencies.add(ModuleIdentifier.create("org.wildfly.security.elytron"));
+        archiveDependencies.add(ModuleIdentifier.create("java.logging"));
 
         // Merge the auxiliary archives and collect the loadable extensions
         final Set<String> loadableExtensions = new HashSet<String>();


### PR DESCRIPTION
…logging dependency which is required for newer versions of WildFly, but not older versions.

https://issues.jboss.org/browse/WFARQ-43