### PR TITLE
[WFARQ-51] modulePath without WILDFLY_HOME/modules, NPE fix

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/CommonDeployableContainer.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/CommonDeployableContainer.java
@@ -263,7 +263,10 @@ public abstract class CommonDeployableContainer<T extends CommonContainerConfigu
     private void safeCloseClient() {
         try {
             // Reset the client, this should close the internal resources and setup reinitialization
-            getManagementClient().reset();
+            ManagementClient client = getManagementClient();
+            if (client != null) {
+                client.reset();
+            }
         } catch (final Exception e) {
             Logger.getLogger(getClass()).warn("Caught exception closing ManagementClient", e);
         } finally {

--- a/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
+++ b/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
@@ -86,7 +86,7 @@ public class ManagedDomainDeployableContainer extends CommonDomainDeployableCont
 
             final String modulesPath = config.getModulePath();
             if (modulesPath != null && !modulesPath.isEmpty()) {
-                commandBuilder.addModuleDirs(modulesPath.split(Pattern.quote(File.pathSeparator)));
+                commandBuilder.setModuleDirs(modulesPath.split(Pattern.quote(File.pathSeparator)));
             }
 
             if (config.isEnableAssertions()) {

--- a/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
+++ b/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
@@ -87,7 +87,7 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
 
             String modulesPath = config.getModulePath();
             if (modulesPath != null && !modulesPath.isEmpty()) {
-                commandBuilder.addModuleDirs(modulesPath.split(Pattern.quote(File.pathSeparator)));
+                commandBuilder.setModuleDirs(modulesPath.split(Pattern.quote(File.pathSeparator)));
             }
 
             String bundlesPath = config.getBundlePath();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFARQ-51
* modulePath arquillian property should override module.path passed into the server, default WILDFLY_HOME/modules should be removed (causes Duplicate layer 'base' warnings, only one place in wildfly testsuite where this is used - and there is the Duplicate layer warning to fix too - see https://issues.jboss.org/browse/WFLY-10631)
* fixed minor NPE visible in the same log

~When this will be fixed, fix of https://issues.jboss.org/browse/WFLY-10631 will be required in wildfly to not break the tests on upgrade.~