### PR TITLE
[WFARQ-51] modulePath without WILDFLY_HOME/modules

### DIFF
--- a/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
+++ b/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
@@ -86,7 +86,7 @@ public class ManagedDomainDeployableContainer extends CommonDomainDeployableCont
 
             final String modulesPath = config.getModulePath();
             if (modulesPath != null && !modulesPath.isEmpty()) {
-                commandBuilder.addModuleDirs(modulesPath.split(Pattern.quote(File.pathSeparator)));
+                commandBuilder.setModuleDirs(modulesPath.split(Pattern.quote(File.pathSeparator)));
             }
 
             if (config.isEnableAssertions()) {

--- a/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
+++ b/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
@@ -87,7 +87,7 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
 
             String modulesPath = config.getModulePath();
             if (modulesPath != null && !modulesPath.isEmpty()) {
-                commandBuilder.addModuleDirs(modulesPath.split(Pattern.quote(File.pathSeparator)));
+                commandBuilder.setModuleDirs(modulesPath.split(Pattern.quote(File.pathSeparator)));
             }
 
             String bundlesPath = config.getBundlePath();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFARQ-51