### PR TITLE
add debug properties

### DIFF
--- a/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
+++ b/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
@@ -61,7 +61,30 @@ public class ManagedContainerConfiguration extends DistributionContainerConfigur
 
     private String cleanServerBaseDir;
 
+    private boolean debugMode = false;
+
+    private int debugPort = 8787;
+
+    private boolean debugSuspend = false;
+
     public ManagedContainerConfiguration() {
+        if (System.getProperty("jboss.debug", "false").equalsIgnoreCase("true")) {
+            debugMode = true;
+        }
+        if (System.getProperty("jboss.debug.port") != null) {
+            try {
+                int port = Integer.parseInt(System.getProperty("jboss.debug.port"));
+                // linux does not allow allocation of ports lower than 1024 if non root
+                if (port > 1024) {
+                    debugPort = port;
+                }
+            } catch (NumberFormatException e) {
+                // do nothing
+            }
+        }
+        if (System.getProperty("jboss.debug.suspend", "false").equalsIgnoreCase("true")) {
+            debugSuspend = true;
+        }
     }
 
     @Override
@@ -186,5 +209,29 @@ public class ManagedContainerConfiguration extends DistributionContainerConfigur
 
     public void setCleanServerBaseDir(String cleanServerBaseDir) {
         this.cleanServerBaseDir = cleanServerBaseDir;
+    }
+
+    public boolean isDebugMode() {
+        return debugMode;
+    }
+
+    public void setDebugMode(boolean debugMode) {
+        this.debugMode = debugMode;
+    }
+
+    public int getDebugPort() {
+        return debugPort;
+    }
+
+    public void setDebugPort(int debugPort) {
+        this.debugPort = debugPort;
+    }
+
+    public boolean isDebugSuspend() {
+        return debugSuspend;
+    }
+
+    public void setDebugSuspend(boolean debugSuspend) {
+        this.debugSuspend = debugSuspend;
     }
 }

--- a/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
+++ b/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
@@ -118,6 +118,10 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
                 commandBuilder.setServerConfiguration(config.getServerConfig());
             }
 
+            if (config.isDebugMode()) {
+                commandBuilder.setDebug(config.isDebugSuspend(), config.getDebugPort());
+            }
+
             // Create a clean server base to run the container; ARQ-638
             if (config.isSetupCleanServerBaseDir() || config.getCleanServerBaseDir() != null) {
                 setupCleanServerDirectories(commandBuilder, config.getCleanServerBaseDir());


### PR DESCRIPTION
Allow to activate debugging with `-Djboss.debug=true` instead of using `jvmArguments` in arquillian.xml for the use case you need some special `jvmArguments` and do not want to have multiple configurations just for debugging.