### PR TITLE
[WFARQ-65] Add bootable JAR container support

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,4 +33,4 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build with Maven Java ${{ matrix.java }}
-        run: mvn clean verify
+        run: mvn clean verify '-Dorg.wildfly.logging.skipLogManagerCheck=true'

--- a/container-bootable/pom.xml
+++ b/container-bootable/pom.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.arquillian</groupId>
+        <artifactId>wildfly-arquillian-parent</artifactId>
+        <version>3.0.0.Beta1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>wildfly-arquillian-container-bootable</artifactId>
+    <name>WildFly: Arquillian Bootable jar Container</name>
+    <packaging>jar</packaging>
+    
+    <properties>
+        <version.wildfly>20.0.0.Final</version.wildfly>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-nio</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling-river</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.remoting</groupId>
+            <artifactId>jboss-remoting</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.remotingjmx</groupId>
+            <artifactId>remoting-jmx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-launcher</artifactId>
+        </dependency>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.protocol</groupId>
+            <artifactId>arquillian-protocol-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- needed only for InjectJndiContextTestCase#shouldInjectJndiContext-->
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-ejb-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-jar-maven-plugin</artifactId>   
+                <version>2.0.0.Beta1</version>
+                <configuration>
+                    <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#${version.wildfly}</feature-pack-location>
+                    <hollowJar>true</hollowJar>
+                    <outputFileName>test-wildfly.jar</outputFileName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <skip>false</skip>
+                            <excludedGroups>org.jboss.as.arquillian.container.managed.manual.ManualMode</excludedGroups>
+                            <systemPropertyVariables>
+                                <install.dir>${jboss.home}</install.dir>
+                                <bootable.jar>target/test-wildfly.jar</bootable.jar>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>manual</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <skip>false</skip>
+                            <groups>org.jboss.as.arquillian.container.managed.manual.ManualMode</groups>
+                            <systemPropertyVariables>
+                                <arquillian.xml>manual-arquillian.xml</arquillian.xml>
+                                <install.dir>${jboss.home}</install.dir>
+                                <bootable.jar>target/test-wildfly.jar</bootable.jar>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/container-bootable/src/main/java/org/jboss/as/arquillian/container/bootable/BootableContainerConfiguration.java
+++ b/container-bootable/src/main/java/org/jboss/as/arquillian/container/bootable/BootableContainerConfiguration.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.bootable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
+import org.jboss.arquillian.container.spi.ConfigurationException;
+import org.jboss.as.arquillian.container.CommonContainerConfiguration;
+
+/**
+ * The managed container configuration
+ *
+ * @author jdenise@redhat.com
+ */
+public class BootableContainerConfiguration extends CommonContainerConfiguration {
+
+    private String javaHome = System.getenv("JAVA_HOME");
+
+    private String jarFile;
+    private String installDir;
+
+    /**
+     * Default timeout value waiting on ports is 10 seconds
+     */
+    private static final Integer DEFAULT_VALUE_WAIT_FOR_PORTS_TIMEOUT_SECONDS = 10;
+
+    private String javaVmArguments = System.getProperty("jboss.options");
+
+    private String jbossArguments;
+
+    private int startupTimeoutInSeconds = 60;
+
+    private int stopTimeoutInSeconds = 60;
+
+    private boolean outputToConsole = true;
+
+    private boolean allowConnectingToRunningServer = Boolean.parseBoolean(System.getProperty("allowConnectingToRunningServer", "false"));
+
+    private boolean enableAssertions = true;
+
+    private Integer[] waitForPorts;
+
+    private Integer waitForPortsTimeoutInSeconds;
+
+    private boolean setupCleanServerBaseDir = false;
+
+    private String cleanServerBaseDir;
+
+    public BootableContainerConfiguration() {
+        // if no javaHome is set use java.home of already running jvm
+        if (javaHome == null || javaHome.isEmpty()) {
+            javaHome = System.getProperty("java.home");
+        }
+    }
+
+    @Override
+    public void validate() throws ConfigurationException {
+        super.validate();
+    }
+
+    /**
+     * @return the javaHome
+     */
+    public String getJavaHome() {
+        return javaHome;
+    }
+
+    /**
+     * @param javaHome the javaHome to set
+     */
+    public void setJavaHome(String javaHome) {
+        this.javaHome = javaHome;
+    }
+
+    public String getJavaVmArguments() {
+        return javaVmArguments;
+    }
+
+    public void setJavaVmArguments(String javaVmArguments) {
+        this.javaVmArguments = javaVmArguments;
+    }
+
+    public String getJbossArguments() {
+        return jbossArguments;
+    }
+
+    public void setJbossArguments(String jbossArguments) {
+        this.jbossArguments = jbossArguments;
+    }
+
+    public void setStartupTimeoutInSeconds(int startupTimeoutInSeconds) {
+        this.startupTimeoutInSeconds = startupTimeoutInSeconds;
+    }
+
+    public int getStartupTimeoutInSeconds() {
+        return startupTimeoutInSeconds;
+    }
+
+    public void setStopTimeoutInSeconds(int stopTimeoutInSeconds) {
+        this.stopTimeoutInSeconds = stopTimeoutInSeconds;
+    }
+
+    /**
+     * Number of seconds to wait for the container process to shutdown; defaults
+     * to 60
+     */
+    public int getStopTimeoutInSeconds() {
+        return stopTimeoutInSeconds;
+    }
+
+    public void setOutputToConsole(boolean outputToConsole) {
+        this.outputToConsole = outputToConsole;
+    }
+
+    public boolean isOutputToConsole() {
+        return outputToConsole;
+    }
+
+    /**
+     * Get the bootable jar file.
+     */
+    public String getJarFile() {
+        return jarFile;
+    }
+
+    /**
+     * Set the bootable jar file.
+     */
+    public void setJarFile(String jarFile) {
+        this.jarFile = jarFile;
+    }
+
+    public boolean isAllowConnectingToRunningServer() {
+        return allowConnectingToRunningServer;
+    }
+
+    public void setAllowConnectingToRunningServer(final boolean allowConnectingToRunningServer) {
+        this.allowConnectingToRunningServer = allowConnectingToRunningServer;
+    }
+
+    public boolean isEnableAssertions() {
+        return enableAssertions;
+    }
+
+    public void setEnableAssertions(final boolean enableAssertions) {
+        this.enableAssertions = enableAssertions;
+    }
+
+    public Integer[] getWaitForPorts() {
+        return waitForPorts;
+    }
+
+    public void setWaitForPorts(String waitForPorts) {
+        final Scanner scanner = new Scanner(waitForPorts);
+        final List<Integer> list = new ArrayList<Integer>();
+        while (scanner.hasNextInt()) {
+            list.add(scanner.nextInt());
+        }
+        this.waitForPorts = list.toArray(new Integer[]{});
+    }
+
+    public Integer getWaitForPortsTimeoutInSeconds() {
+        return waitForPortsTimeoutInSeconds != null ? waitForPortsTimeoutInSeconds
+                : DEFAULT_VALUE_WAIT_FOR_PORTS_TIMEOUT_SECONDS;
+    }
+
+    public void setWaitForPortsTimeoutInSeconds(final Integer waitForPortsTimeoutInSeconds) {
+        this.waitForPortsTimeoutInSeconds = waitForPortsTimeoutInSeconds;
+    }
+
+    public String getInstallDir() {
+        return installDir;
+    }
+
+    public void setInstallDir(String installDir) {
+        this.installDir = installDir;
+    }
+
+    public boolean isSetupCleanServerBaseDir() {
+        return setupCleanServerBaseDir;
+    }
+
+    public void setSetupCleanServerBaseDir(boolean setupCleanServerBaseDir) {
+        this.setupCleanServerBaseDir = setupCleanServerBaseDir;
+    }
+
+    public String getCleanServerBaseDir() {
+        return cleanServerBaseDir;
+    }
+
+    public void setCleanServerBaseDir(String cleanServerBaseDir) {
+        this.cleanServerBaseDir = cleanServerBaseDir;
+    }
+}

--- a/container-bootable/src/main/java/org/jboss/as/arquillian/container/bootable/BootableContainerExtension.java
+++ b/container-bootable/src/main/java/org/jboss/as/arquillian/container/bootable/BootableContainerExtension.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.bootable;
+
+import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.as.arquillian.container.CommonContainerExtension;
+
+/**
+ * The extensions used by the managed container.
+ *
+ * @author jdenise@redhat.com
+ */
+public class BootableContainerExtension extends CommonContainerExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        super.register(builder);
+        builder.service(DeployableContainer.class, BootableDeployableContainer.class);
+    }
+}

--- a/container-bootable/src/main/java/org/jboss/as/arquillian/container/bootable/BootableDeployableContainer.java
+++ b/container-bootable/src/main/java/org/jboss/as/arquillian/container/bootable/BootableDeployableContainer.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.bootable;
+
+import org.jboss.arquillian.container.spi.client.container.LifecycleException;
+import org.jboss.as.arquillian.container.CommonDeployableContainer;
+import org.jboss.as.arquillian.container.ParameterUtils;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.core.launcher.Launcher;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.DatagramSocket;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Logger;
+import org.wildfly.core.launcher.BootableJarCommandBuilder;
+
+import static org.wildfly.core.launcher.ProcessHelper.addShutdownHook;
+import static org.wildfly.core.launcher.ProcessHelper.destroyProcess;
+import static org.wildfly.core.launcher.ProcessHelper.processHasDied;
+
+/**
+ * The managed deployable container.
+ *
+ * @author jdenise@redhat.com
+ */
+public final class BootableDeployableContainer extends CommonDeployableContainer<BootableContainerConfiguration> {
+
+    static final String TEMP_CONTAINER_DIRECTORY = "arquillian-temp-container";
+
+    static final String CONFIG_DIR = "configuration";
+    static final String DATA_DIR = "data";
+
+    private static final int PORT_RANGE_MIN = 1;
+    private static final int PORT_RANGE_MAX = 65535;
+
+    private final Logger log = Logger.getLogger(BootableDeployableContainer.class.getName());
+    private Thread shutdownThread;
+    private Process process;
+    private boolean timeoutSupported = false;
+
+    @Override
+    public Class<BootableContainerConfiguration> getConfigurationClass() {
+        return BootableContainerConfiguration.class;
+    }
+
+    @Override
+    protected void startInternal() throws LifecycleException {
+        BootableContainerConfiguration config = getContainerConfiguration();
+
+        if (isServerRunning()) {
+            if (config.isAllowConnectingToRunningServer()) {
+                return;
+            } else {
+                failDueToRunning();
+            }
+        }
+
+        try {
+            final BootableJarCommandBuilder commandBuilder = BootableJarCommandBuilder.of(config.getJarFile());
+            final String path = config.getInstallDir();
+            if (path != null) {
+                final Path installDir = Paths.get(path);
+                // Workaround for https://issues.redhat.com/browse/WFCORE-5062
+                if (Files.notExists(installDir)) {
+                    Files.createDirectories(installDir);
+                }
+                commandBuilder.setInstallDir(installDir);
+            }
+
+            final String javaOpts = config.getJavaVmArguments();
+            final String jbossArguments = config.getJbossArguments();
+
+            commandBuilder.setJavaHome(config.getJavaHome());
+            if (javaOpts != null && !javaOpts.trim().isEmpty()) {
+                commandBuilder.setJavaOptions(ParameterUtils.splitParams(javaOpts));
+            }
+
+            if (config.isEnableAssertions()) {
+                commandBuilder.addJavaOption("-ea");
+            }
+
+            if (jbossArguments != null && !jbossArguments.trim().isEmpty()) {
+                commandBuilder.addServerArguments(ParameterUtils.splitParams(jbossArguments));
+            }
+
+            // Wait on ports before launching; AS7-4070
+            this.waitOnPorts();
+
+
+            log.info("Starting container with: " + commandBuilder.build());
+            process = Launcher.of(commandBuilder).setRedirectErrorStream(true).launch();
+            new Thread(new ConsoleConsumer()).start();
+            shutdownThread = addShutdownHook(process);
+
+            long startupTimeout = getContainerConfiguration().getStartupTimeoutInSeconds();
+            long timeout = startupTimeout * 1000;
+            boolean serverAvailable = false;
+            long sleep = 1000;
+            while (timeout > 0 && serverAvailable == false) {
+                long before = System.currentTimeMillis();
+                serverAvailable = getManagementClient().isServerInRunningState();
+                timeout -= (System.currentTimeMillis() - before);
+                if (!serverAvailable) {
+                    if (processHasDied(process)) {
+                        final String msg = String.format("The java process starting the bootable server exited unexpectedly with code [%d]", process.exitValue());
+                        throw new LifecycleException(msg);
+                    }
+                    Thread.sleep(sleep);
+                    timeout -= sleep;
+                    sleep = Math.max(sleep / 2, 100);
+                }
+            }
+            if (!serverAvailable) {
+                destroyProcess(process);
+                throw new TimeoutException(String.format("Bootable server was not started within [%d] s", getContainerConfiguration().getStartupTimeoutInSeconds()));
+            }
+            timeoutSupported = isOperationAttributeSupported("shutdown", "timeout");
+
+        } catch (LifecycleException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new LifecycleException("Could not start container", e);
+        }
+    }
+
+    /**
+     * If specified in the configuration, waits on the specified ports to become
+     * available for the specified time, else throws a {@link PortAcquisitionTimeoutException}
+     *
+     * @throws PortAcquisitionTimeoutException
+     */
+    private void waitOnPorts() throws PortAcquisitionTimeoutException {
+        // Get the config
+        final Integer[] ports = this.getContainerConfiguration().getWaitForPorts();
+        final int timeoutInSeconds = this.getContainerConfiguration().getWaitForPortsTimeoutInSeconds();
+
+        // For all ports we'll wait on
+        if (ports != null && ports.length > 0) {
+            for (int i = 0; i < ports.length; i++) {
+                final int port = ports[i];
+                final long start = System.currentTimeMillis();
+                // If not available
+                while (!this.isPortAvailable(port)) {
+
+                    // Get time elapsed
+                    final int elapsedSeconds = (int) ((System.currentTimeMillis() - start) / 1000);
+
+                    // See that we haven't timed out
+                    if (elapsedSeconds > timeoutInSeconds) {
+                        throw new PortAcquisitionTimeoutException(port, timeoutInSeconds);
+                    }
+                    try {
+                        // Wait a bit, then try again.
+                        Thread.sleep(500);
+                    } catch (final InterruptedException e) {
+                        Thread.interrupted();
+                    }
+
+                    // Log that we're waiting
+                    log.warning("Waiting on port " + port + " to become available for "
+                            + (timeoutInSeconds - elapsedSeconds) + "s");
+                }
+            }
+        }
+    }
+
+    private boolean isPortAvailable(final int port) {
+        // Precondition checks
+        if (port < PORT_RANGE_MIN || port > PORT_RANGE_MAX) {
+            throw new IllegalArgumentException("Port specified is out of range: " + port);
+        }
+
+        ServerSocket ss = null;
+        DatagramSocket ds = null;
+        try {
+            // Attempt both TCP and UDP
+            ss = new ServerSocket(port);
+            ds = new DatagramSocket(port);
+            // So we don't block from using this port while it's in a TIMEOUT state after we release it
+            ss.setReuseAddress(true);
+            ds.setReuseAddress(true);
+            // Could be acquired
+            return true;
+        } catch (final IOException e) {
+            // Swallow
+        } finally {
+            if (ds != null) {
+                ds.close();
+            }
+            if (ss != null) {
+                try {
+                    ss.close();
+                } catch (final IOException e) {
+                    // Swallow
+
+                }
+            }
+        }
+
+        // Couldn't be acquired
+        return false;
+    }
+
+
+    @Override
+    protected void stopInternal(final Integer timeout) throws LifecycleException {
+        if (shutdownThread != null) {
+            Runtime.getRuntime().removeShutdownHook(shutdownThread);
+            shutdownThread = null;
+        }
+        try {
+            if (process != null) {
+                Thread shutdown = new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            Thread.sleep(getContainerConfiguration().getStopTimeoutInSeconds() * 1000);
+                        } catch (InterruptedException e) {
+                            return;
+                        }
+
+                        // The process hasn't shutdown within 60 seconds. Terminate forcibly.
+                        if (process != null) {
+                            process.destroy();
+                        }
+                    }
+                });
+                shutdown.start();
+
+                // AS7-6620: Create the shutdown operation and run it asynchronously and wait for process to terminate
+                final ModelNode op = Operations.createOperation("shutdown");
+                if (timeoutSupported) {
+                    if (timeout != null) {
+                        op.get("timeout").set(timeout);
+                    }
+                } else {
+                    log.severe(String.format("Timeout is not supported for %s on the shutdown operation.", getContainerDescription()));
+                }
+                getManagementClient().getControllerClient().executeAsync(op, null);
+
+                process.waitFor();
+                process = null;
+
+                shutdown.interrupt();
+            }
+        } catch (Exception e) {
+            try {
+                destroyProcess(process);
+            }catch (Exception ignore) {}
+            throw new LifecycleException("Could not stop container", e);
+        }
+    }
+
+    private boolean isServerRunning() {
+        Socket socket = null;
+        try {
+            socket = new Socket(
+                    getContainerConfiguration().getManagementAddress(),
+                    getContainerConfiguration().getManagementPort());
+        } catch (Exception ignored) { // nothing is running on defined ports
+            return false;
+        } finally {
+            if (socket != null) {
+                try {
+                    socket.close();
+                } catch (Exception e) {
+                    throw new RuntimeException("Could not close isServerStarted socket", e);
+                }
+            }
+        }
+        return true;
+    }
+
+    private void failDueToRunning() throws LifecycleException {
+        final int managementPort = getContainerConfiguration().getManagementPort();
+        throw new LifecycleException(
+                String.format("The port %1$d is already in use. It means that either the server might be already running " +
+                                "or there is another process using port %1$d.%n" +
+                                "Managed containers do not support connecting to running server instances due to the " +
+                                "possible harmful effect of connecting to the wrong server.%n" +
+                                "Please stop server (or another process) before running, " +
+                                "change to another type of container (e.g. remote) or use jboss.socket.binding.port-offset variable " +
+                                "to change the default port.%n" +
+                                "To disable this check and allow Arquillian to connect to a running server, " +
+                                "set allowConnectingToRunningServer to true in the container configuration",
+                        managementPort));
+    }
+
+    /**
+     * Runnable that consumes the output of the process. If nothing consumes the output the AS will hang on some platforms
+     *
+     * @author Stuart Douglas
+     */
+    private class ConsoleConsumer implements Runnable {
+
+        @Override
+        public void run() {
+            final InputStream stream = process.getInputStream();
+            final boolean writeOutput = getContainerConfiguration().isOutputToConsole();
+
+            try {
+                byte[] buf = new byte[32];
+                int num;
+                // Do not try reading a line cos it considers '\r' end of line
+                while ((num = stream.read(buf)) != -1) {
+                    if (writeOutput)
+                        System.out.write(buf, 0, num);
+                }
+            } catch (IOException e) {
+            }
+        }
+
+    }
+}

--- a/container-bootable/src/main/java/org/jboss/as/arquillian/container/bootable/PortAcquisitionTimeoutException.java
+++ b/container-bootable/src/main/java/org/jboss/as/arquillian/container/bootable/PortAcquisitionTimeoutException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.bootable;
+
+import org.jboss.arquillian.container.spi.client.container.LifecycleException;
+
+/**
+ * Denotes that a port could not be obtained within a designated timeout period.
+ *
+ * @author <a href="mailto:alr@jboss.org">ALR</a>
+ * @see {@link https://issues.jboss.org/browse/AS7-4070}
+ */
+public class PortAcquisitionTimeoutException extends LifecycleException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new instance noting the port that could not be acquired in the designated amount of time
+     *
+     * @param port
+     * @param timeoutSeconds
+     */
+    public PortAcquisitionTimeoutException(final int port, final int timeoutSeconds) {
+        super("Could not acquire requested port " + port + " in " + timeoutSeconds + " seconds");
+    }
+}

--- a/container-bootable/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/container-bootable/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,17 @@
+#
+# Copyright 2020 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.jboss.as.arquillian.container.bootable.BootableContainerExtension

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/AbstractContainerTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/AbstractContainerTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import javax.management.Attribute;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+
+import org.junit.Test;
+
+/**
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ * @author Thomas.Diesler@jboss.com
+ */
+public abstract class AbstractContainerTestCase {
+
+    @Test
+    public void testDeployedService() throws Exception {
+        MBeanServerConnection mbeanServer = getMBeanServer();
+        ObjectName objectName = new ObjectName("jboss:name=test,type=config");
+
+        //FIXME should have some notification happening when the deployment has been installed for client
+        waitForMbean(mbeanServer, objectName);
+
+        mbeanServer.getAttribute(objectName, "IntervalSeconds");
+        mbeanServer.setAttribute(objectName, new Attribute("IntervalSeconds", 2));
+    }
+
+    abstract MBeanServerConnection getMBeanServer() throws Exception;
+
+    void waitForMbean(MBeanServerConnection mbeanServer, ObjectName name) throws Exception {
+        //FIXME remove this
+        long end = System.currentTimeMillis() + 3000;
+        do {
+            try {
+                MBeanInfo info = mbeanServer.getMBeanInfo(name);
+                if (info != null) {
+                    return;
+                }
+            } catch (Exception e) {
+            }
+            Thread.sleep(100);
+        } while (System.currentTimeMillis() < end);
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ClientDeploymentTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ClientDeploymentTestCase.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ArchiveDeployer;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test deploying through an injected {@link ArchiveDeployer}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ClientDeploymentTestCase {
+
+    @ArquillianResource
+    private ArchiveDeployer deployer;
+
+    @Deployment
+    public static WebArchive create() {
+        return createDeployment(null);
+    }
+
+    @Test
+    public void globalDeploymentTest(@ArquillianResource ManagementClient client) throws Exception {
+        Assert.assertNotNull("Expected the ArchiveDeployer to be injected", deployer);
+        testDeploy(deployer, client);
+    }
+
+    @Test
+    public void parameterDeploymentTest(@ArquillianResource ManagementClient client, @ArquillianResource ArchiveDeployer deployer) throws Exception {
+        Assert.assertNotNull("Expected the ArchiveDeployer to be injected", deployer);
+        testDeploy(deployer, client);
+    }
+
+    private void testDeploy(final ArchiveDeployer deployer, final ManagementClient client) throws Exception {
+        final WebArchive deployment = createDeployment("test-client-deployment.war");
+        Assert.assertEquals(deployment.getName(), deployer.deploy(deployment));
+
+        // Check the server for the deployment
+        final ModelNode address = Operations.createAddress("deployment", deployment.getName());
+        final ModelNode result = client.getControllerClient().execute(Operations.createReadAttributeOperation(address, "status"));
+        if (!Operations.isSuccessfulOutcome(result)) {
+            Assert.fail(Operations.getFailureDescription(result).asString());
+        }
+        Assert.assertEquals("OK", Operations.readResult(result).asString());
+        deployer.undeploy(deployment.getName());
+    }
+
+    private static WebArchive createDeployment(final String name) {
+        if (name == null) {
+            return ShrinkWrap.create(WebArchive.class)
+                    .addClass(HelloWorldServlet.class);
+        }
+        return ShrinkWrap.create(WebArchive.class, name)
+                .addClass(HelloWorldServlet.class);
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/DeploymentTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/DeploymentTestCase.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests basic deployment
+ */
+@RunWith(Arquillian.class)
+public class DeploymentTestCase {
+
+    @Deployment
+    public static JavaArchive create() {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+                .addClass(SystemPropertyServiceActivator.class)
+                .addAsServiceProvider(ServiceActivator.class, SystemPropertyServiceActivator.class);
+        return archive;
+    }
+
+    @Test
+    public void testSystemPropSet() throws Exception {
+        Assert.assertEquals(SystemPropertyServiceActivator.VALUE, System.getProperty(SystemPropertyServiceActivator.TEST_PROPERTY));
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/EjbBean.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/EjbBean.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+/**
+ * Test EJB used for binding only
+ * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
+ */
+@Stateless
+@Remote(EjbBusiness.class)
+public class EjbBean implements EjbBusiness {
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/EjbBusiness.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/EjbBusiness.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import javax.ejb.Remote;
+
+/**
+ * EJB Business Interface
+ * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
+ */
+@Remote
+public interface EjbBusiness {
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/HelloWorldServlet.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/HelloWorldServlet.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A basic "hello world" servlet for testing client-side invocation in an Arquillian test.
+ *
+ * @author <a href="http://community.jboss.org/people/dan.j.allen">Dan Allen</a>
+ */
+@WebServlet(name = "HelloWorldServlet", urlPatterns = HelloWorldServlet.URL_PATTERN)
+public class HelloWorldServlet extends HttpServlet {
+    private static final long serialVersionUID = 2202174128107400113L;
+    
+    public static final String URL_PATTERN = "/greet";
+    
+    public static final String GREETING = "Hello, World";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+        res.setContentType("text/plain");
+        res.getWriter().append(GREETING);
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/InjectJndiContextTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/InjectJndiContextTestCase.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import javax.naming.Context;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * AS7-3111 Ensures the JNDI Naming {@link Context} can be injected
+ *
+ * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class InjectJndiContextTestCase {
+
+    /**
+     * Test EJB deployment w/ remote binding
+     */
+    @Deployment(testable = false)
+    public static JavaArchive createDeployment() throws Exception {
+        return ShrinkWrap.create(JavaArchive.class,"myejb.jar").addClasses(EjbBean.class,EjbBusiness.class);
+    }
+
+    /**
+     * {@link Context} to be injected
+     */
+    @ArquillianResource
+    private Context jndiContext;
+    
+    private static final String JNDI_NAME = "ejb:/myejb//EjbBean!org.jboss.as.arquillian.container.managed.EjbBusiness";
+
+    /**
+     * AS7-3111
+     */
+    @Test
+    public void shouldInjectJndiContext() throws NamingException {
+        Assert.assertNotNull("AS7-3111: JNDI Context must be injected", jndiContext);
+        // Attempt to look up the remote EJB
+        final EjbBusiness ejb = (EjbBusiness)jndiContext.lookup(JNDI_NAME);
+        Assert.assertNotNull("Could not look up datasource using supplied JNDI Context", ejb);
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/InjectManagementClientTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/InjectManagementClientTestCase.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * AS7-1415 Ensures injection of the {@link ManagementClient} is working correctly
+ *
+ * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
+ */
+@RunWith(Arquillian.class)
+public class InjectManagementClientTestCase {
+
+    @ArquillianResource
+    private ManagementClient managementClient;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() throws Exception {
+        return ShrinkWrap.create(WebArchive.class).addClass(HelloWorldServlet.class);
+    }
+
+    @Test
+    public void ensureManagementClientInjected() {
+        Assert.assertNotNull("Management client must be injected", managementClient);
+        Assert.assertTrue("Management client should report server as running",
+                managementClient.isServerInRunningState());
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/IntegrationTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/IntegrationTestCase.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.container.managed.archive.GreetingService;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * IntegrationTestCase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ */
+@RunWith(Arquillian.class)
+public class IntegrationTestCase {
+
+    @Deployment
+    public static JavaArchive create() {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class).addClass(GreetingService.class);
+        archive.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return archive;
+    }
+
+    @Inject
+    private GreetingService service;
+
+    @Test
+    public void shouldBeAbleToInject() throws Exception {
+        Assert.assertNotNull(service);
+        Assert.assertEquals("Hello Earthling!", service.greet("Earthling"));
+    }
+
+    @Test
+    public void shouldBeAbleToFetchSystemProperties() throws Exception {
+        final String prop1 = System.getProperties().getProperty("org.jboss.as.arquillian.container.managed.prop1");
+        final String prop2 = System.getProperties().getProperty("org.jboss.as.arquillian.container.managed.prop2");
+        Assert.assertEquals("prop1", prop1);
+        Assert.assertEquals("prop2", prop2);
+    }
+
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientEnterpriseArchiveServletTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientEnterpriseArchiveServletTestCase.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * A client-side test case that verifies that the root deployment URL can be injected
+ * into the test case.
+ *
+ * @author <a href="http://community.jboss.org/people/dan.j.allen">Dan Allen</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ManagedAsClientEnterpriseArchiveServletTestCase {
+
+    private static final String CONTEXT_NAME = "test-hello-world";
+
+    @Deployment(testable = false)
+    public static EnterpriseArchive createDeployment() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class,  CONTEXT_NAME + ".war").addClass(HelloWorldServlet.class);
+        return ShrinkWrap.create(EnterpriseArchive.class).addAsModule(war);
+    }
+
+    @ArquillianResource
+    private URL deploymentUrl;
+
+    @Test
+    public void shouldBeAbleToInvokeServlet() throws Exception {
+        Assert.assertNotNull(deploymentUrl);
+        String result = getContent(new URL(deploymentUrl.toString() + HelloWorldServlet.URL_PATTERN.substring(1)));
+        Assert.assertEquals(HelloWorldServlet.GREETING, result);
+    }
+
+    @Test
+    public void testWebContext() {
+        Assert.assertTrue(String.format("Expected context to start with /%s, but found %s", CONTEXT_NAME, deploymentUrl.getPath()),
+                deploymentUrl.getPath().startsWith("/" + CONTEXT_NAME));
+    }
+
+    private String getContent(URL url) throws Exception {
+        InputStream is = url.openStream();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            int read;
+            while ((read = is.read()) != -1) {
+                out.write(read);
+            }
+        } finally {
+            try {
+                is.close();
+            } catch (Exception e) {
+            }
+        }
+        return out.toString();
+    }
+
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientTestCase.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import java.io.File;
+import java.net.URL;
+import javax.management.MBeanServerConnection;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.container.MBeanServerConnectionProvider;
+import org.jboss.as.arquillian.container.managed.archive.ConfigService;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.xnio.IoUtils;
+
+/**
+ * JBossASRemoteIntegrationTestCase
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ * @author Thomas.Diesler@jboss.com
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+// Ignored, requires sar not present in standalone-microprofile.xml
+@Ignore
+public class ManagedAsClientTestCase extends AbstractContainerTestCase {
+    private MBeanServerConnectionProvider provider;
+
+    @Deployment(testable = false)
+    public static JavaArchive createDeployment() throws Exception {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "sar-example.sar");
+        archive.addPackage(ConfigService.class.getPackage());
+        String path = "META-INF/jboss-service.xml";
+        URL resourceURL = ManagedAsClientTestCase.class.getResource("/sar-example.sar/" + path);
+        archive.addAsResource(new File(resourceURL.getFile()), path);
+        return archive;
+    }
+
+    @Override
+    protected MBeanServerConnection getMBeanServer() throws Exception {
+        assert provider == null;
+        provider = MBeanServerConnectionProvider.defaultProvider();
+        return provider.getConnection();
+    }
+
+    @After
+    public void closeProvider() {
+        IoUtils.safeClose(provider);
+    }
+
+    @Override
+    public void testDeployedService() throws Exception {
+        super.testDeployedService();
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientWebArchiveServletTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientWebArchiveServletTestCase.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * A client-side test case that verifies that the root deployment URL can be injected
+ * into the test case.
+ *
+ * @author <a href="http://community.jboss.org/people/dan.j.allen">Dan Allen</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ManagedAsClientWebArchiveServletTestCase {
+
+    private static final String CONTEXT_NAME = "foo-v1.2";
+
+    @Deployment(testable = false)
+    @OverProtocol("Servlet 3.0")
+    public static WebArchive createDeployment() throws Exception {
+        return ShrinkWrap.create(WebArchive.class, CONTEXT_NAME + ".war").addClass(HelloWorldServlet.class);
+    }
+
+    @ArquillianResource
+    URL deploymentUrl;
+
+    @Test
+    public void shouldBeAbleToInvokeServlet() throws Exception {
+        Assert.assertNotNull(deploymentUrl);
+        Assert.assertTrue("deploymentUrl should end with " + CONTEXT_NAME + "/, but is " + deploymentUrl + 
+                ", the context URL seems to be wrong",
+                deploymentUrl.toString().endsWith(CONTEXT_NAME + "/"));
+        String result = getContent(new URL(deploymentUrl.toString() + HelloWorldServlet.URL_PATTERN.substring(1)));
+        Assert.assertEquals(HelloWorldServlet.GREETING, result);
+    }
+
+    @Test
+    public void testWebContext() {
+        Assert.assertTrue(String.format("Expected context to start with /%s but found %s", CONTEXT_NAME, deploymentUrl.getPath()),
+                deploymentUrl.getPath().startsWith("/" + CONTEXT_NAME));
+    }
+
+    private String getContent(URL url) throws Exception {
+        InputStream is = url.openStream();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            int read;
+            while ((read = is.read()) != -1) {
+                out.write(read);
+            }
+        } finally {
+            try {
+                is.close();
+            } catch (Exception e) {
+            }
+        }
+        return out.toString();
+    }
+
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ManagedInContainerTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ManagedInContainerTestCase.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.net.URL;
+import java.net.URLDecoder;
+import javax.management.MBeanServerConnection;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.container.managed.archive.ConfigService;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * ManagedInContainerTestCase
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ * @author Thomas.Diesler@jboss.com
+ */
+// Ignored, requires sar not present in standalone-microprofile.xml
+@Ignore
+@RunWith(Arquillian.class)
+public class ManagedInContainerTestCase extends AbstractContainerTestCase {
+
+    @Deployment
+    public static JavaArchive createDeployment() throws Exception {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "sar-example.sar");
+        archive.addPackage(ConfigService.class.getPackage());
+        archive.addClasses(AbstractContainerTestCase.class);
+        String path = "META-INF/jboss-service.xml";
+        URL resourceURL = ManagedInContainerTestCase.class.getResource("/sar-example.sar/" + path);
+        String resourceFilePath = URLDecoder.decode(resourceURL.getFile(), "UTF-8");
+        archive.addAsResource(new File(resourceFilePath), path);
+        return archive;
+    }
+
+    @Override
+    MBeanServerConnection getMBeanServer() throws Exception {
+        return ManagementFactory.getPlatformMBeanServer();
+    }
+
+    @Override
+    public void testDeployedService() throws Exception {
+        super.testDeployedService();
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAfterClassTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAfterClassTestCase.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ServerSetupAfterClassTestCase extends TestOperations {
+    @ArquillianResource
+    private ManagementClient client;
+
+    @Deployment
+    public static JavaArchive deployment() {
+        // Create a dummy deployment so the client can be injected
+        return ShrinkWrap.create(JavaArchive.class).addManifest();
+    }
+
+    @Test
+    public void testSystemPropertyRemoved() throws Exception {
+        // All deployments from the ServerSetupDeploymentTestCase should have been undeployed and the
+        // ServerSetupTask.tearDown() should have been invoked
+        testSystemProperty(ServerSetupTestSuite.SYSTEM_PROPERTY_KEY);
+    }
+
+    @Override
+    ManagementClient getClient() {
+        return client;
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupDeploymentTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupDeploymentTestCase.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed;
+
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(ServerSetupDeploymentTestCase.SystemPropertySetupTask.class)
+@RunAsClient
+public class ServerSetupDeploymentTestCase extends TestOperations {
+
+    static class SystemPropertySetupTask implements ServerSetupTask {
+
+        private final ModelNode address = Operations.createAddress("system-property", ServerSetupTestSuite.SYSTEM_PROPERTY_KEY);
+
+        @Override
+        public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+            // Add a system property
+            final ModelNode op = Operations.createAddOperation(address);
+            op.get("value").set(ServerSetupTestSuite.SYSTEM_PROPERTY_VALUE);
+            final ModelNode result = managementClient.getControllerClient().execute(op);
+            if (!Operations.isSuccessfulOutcome(result)) {
+                throw new RuntimeException("Failed to add system property: " + Operations.getFailureDescription(result).asString());
+            }
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+            // Remove the system property
+            final ModelNode op = Operations.createRemoveOperation(address);
+            final ModelNode result = managementClient.getControllerClient().execute(op);
+            if (!Operations.isSuccessfulOutcome(result)) {
+                throw new RuntimeException("Failed to remove system property: " + Operations.getFailureDescription(result).asString());
+            }
+        }
+    }
+
+    private static final String DEPLOYMENT1 = "test-unmanaged-deployment-1.war";
+    private static final String DEPLOYMENT2 = "test-unmanaged-deployment-2.war";
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @ArquillianResource
+    protected ManagementClient client;
+
+
+    @Deployment(name = DEPLOYMENT1)
+    public static WebArchive createDeployment1() throws Exception {
+        return ShrinkWrap.create(WebArchive.class, DEPLOYMENT1)
+                .addClass(HelloWorldServlet.class);
+    }
+
+
+    @Deployment(managed = false, name = DEPLOYMENT2)
+    public static WebArchive createDeployment2() throws Exception {
+        return ShrinkWrap.create(WebArchive.class, DEPLOYMENT2)
+                .addClass(HelloWorldServlet.class);
+    }
+
+    @Test
+    public void testManualUndeploy() throws IOException {
+        // Undeploy the unmanaged deployment even though it's not deployed, this tests whether or not on the AfterClass
+        // listener the tear down will happen.
+        deployer.undeploy(DEPLOYMENT2);
+        // THe system property should still be there because the first deployment is still there
+        testSystemProperty(ServerSetupTestSuite.SYSTEM_PROPERTY_KEY, ServerSetupTestSuite.SYSTEM_PROPERTY_VALUE);
+        // Test leaving an unmanaged deployment deployed to ensure it will be undeployed
+        deployer.deploy(DEPLOYMENT2);
+    }
+
+    @Override
+    ManagementClient getClient() {
+        return client;
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupTestSuite.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupTestSuite.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Ensures the order of the tests to execute in the correct order.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        ServerSetupDeploymentTestCase.class,
+        ServerSetupAfterClassTestCase.class
+})
+public class ServerSetupTestSuite {
+    static final String SYSTEM_PROPERTY_KEY = "server.setup.key";
+    static final String SYSTEM_PROPERTY_VALUE = "server.setup.value";
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/SystemPropertyServiceActivator.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/SystemPropertyServiceActivator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistryException;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * @author Stuart Douglas
+ */
+public class SystemPropertyServiceActivator implements ServiceActivator {
+
+    public static final String TEST_PROPERTY = "test-property";
+    public static final String VALUE = "set";
+
+    @Override
+    public void activate(ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
+        serviceActivatorContext.getServiceTarget().addService(ServiceName.of("test-service"), new Service<Object>() {
+            @Override
+            public void start(StartContext context) throws StartException {
+                System.setProperty(TEST_PROPERTY, VALUE);
+            }
+
+            @Override
+            public void stop(StopContext context) {
+                System.clearProperty(TEST_PROPERTY);
+            }
+
+            @Override
+            public Object getValue() throws IllegalStateException, IllegalArgumentException {
+                return this;
+            }
+        }).install();
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/TestOperations.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/TestOperations.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+abstract class TestOperations {
+
+    abstract ManagementClient getClient();
+
+    void testSystemProperty(final String key) throws IOException {
+        final ModelNode op = Operations.createOperation("read-children-names");
+        op.get("child-type").set("system-property");
+        final List<ModelNode> result = executeForSuccess(getClient(), op).asList();
+        for (ModelNode property : result) {
+            Assert.assertNotEquals(String.format("The key '%s' should have been removed from the server", key), key, property.asString());
+        }
+    }
+
+    void testSystemProperty(final String key, final String value) throws IOException {
+        final ModelNode address = Operations.createAddress("system-property", key);
+        final ModelNode result = executeForSuccess(getClient(), Operations.createReadResourceOperation(address));
+        Assert.assertEquals(value, result.get("value").asString());
+    }
+
+    static ModelNode executeForSuccess(final ManagementClient client, final ModelNode op) throws IOException {
+        final ModelNode result = client.getControllerClient().execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            throw new RuntimeException(String.format("Failed to executeForSuccess operation :%s%n%s", op, Operations.getFailureDescription(result).asString()));
+        }
+        return Operations.readResult(result);
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ThreadContextClassloaderTest.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ThreadContextClassloaderTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.modules.ModuleClassLoader;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class ThreadContextClassloaderTest {
+
+    @Deployment
+    public static JavaArchive deployment() {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "tccl-tests");
+        return archive;
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        assertNoTCCL();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        assertNoTCCL();
+    }
+
+    @Before
+    public void before() throws Exception {
+        assertNoTCCL();
+    }
+
+    @After
+    public void after() throws Exception {
+        assertNoTCCL();
+    }
+
+    @Test
+    public void testClassLoader() throws Exception {
+        assertNoTCCL();
+    }
+
+    private static void assertNoTCCL() {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        Assert.assertFalse("TCCL not ModuleClassLoader: " + tccl, tccl instanceof ModuleClassLoader);
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/UnmanagedDeploymentTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/UnmanagedDeploymentTestCase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests basic deployment
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(UnmanagedDeploymentTestCase.SystemPropertyServerSetup.class)
+@RunAsClient
+public class UnmanagedDeploymentTestCase extends TestOperations {
+
+    private static final String KEY = "test.property.key";
+    private static final String VALUE = "test-value";
+
+    static class SystemPropertyServerSetup implements ServerSetupTask {
+        private final ModelNode address = Operations.createAddress("system-property", KEY);
+
+        @Override
+        public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+            final ModelNode op = Operations.createAddOperation(address);
+            op.get("value").set(VALUE);
+            executeForSuccess(managementClient, op);
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+            executeForSuccess(managementClient, Operations.createRemoveOperation(address));
+        }
+    }
+
+    @ArquillianResource
+    private Deployer deployer;
+    @ArquillianResource
+    private ManagementClient client;
+
+    @Deployment(managed = false, name = "test-deployment")
+    public static JavaArchive create() {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "unmanaged-deployment-test.jar")
+                .addClass(SystemPropertyServiceActivator.class)
+                .addAsServiceProvider(ServiceActivator.class, SystemPropertyServiceActivator.class);
+        return archive;
+    }
+
+    @Test
+    @InSequence(1)
+    public void undeployFirst() throws Exception {
+        // Undeploy first which should not really do anything
+        deployer.undeploy("test-deployment");
+        // Now deploy the deployment which should execute the setup
+        deployer.deploy("test-deployment");
+        testSystemProperty(KEY, VALUE);
+
+    }
+
+    @Test
+    @InSequence(2)
+    public void contentDeployedThenUndeployed() throws Exception {
+        // After the undeploy, the tearDown() won't happen until the class is complete
+        deployer.undeploy("test-deployment");
+        testSystemProperty(KEY, VALUE);
+    }
+
+    @Override
+    ManagementClient getClient() {
+        return client;
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/archive/ConfigService.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/archive/ConfigService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed.archive;
+
+import org.jboss.logging.Logger;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ * @version $Revision: 1.1 $
+ */
+public class ConfigService implements ConfigServiceMBean {
+
+    Logger log = Logger.getLogger(ConfigService.class);
+
+    private int interval;
+
+    public int getIntervalSeconds() {
+        return interval;
+    }
+
+    public void setIntervalSeconds(int interval) {
+        log.info("Setting IntervalSeconds to " + interval);
+        this.interval = interval;
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/archive/ConfigServiceMBean.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/archive/ConfigServiceMBean.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed.archive;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ * @version $Revision: 1.1 $
+ */
+public interface ConfigServiceMBean {
+    int getIntervalSeconds();
+
+    void setIntervalSeconds(int interval);
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/archive/GreetingService.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/archive/GreetingService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed.archive;
+
+/**
+ * GreetingService
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class GreetingService {
+    public String greet(String name) {
+        return "Hello " + name + "!";
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/manual/AbstractManualModeTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/manual/AbstractManualModeTestCase.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed.manual;
+
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@Category(ManualMode.class)
+public abstract class AbstractManualModeTestCase {
+    private static final ModelNode EMPTY_ADDRESS = new ModelNode().setEmptyList();
+    static final String PRIMARY_CONTAINER = "jboss";
+    static final String SECONDARY_CONTAINER = "wildfly";
+
+    @ArquillianResource
+    static ContainerController controller;
+
+    @ArquillianResource
+    @TargetsContainer(PRIMARY_CONTAINER)
+    ManagementClient primaryClient;
+
+    @ArquillianResource
+    @TargetsContainer(SECONDARY_CONTAINER)
+    ManagementClient secondaryClient;
+
+    @Deployment(managed = false, name = "dep1")
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                // Required for JUnit when running in ARQ
+                .addClass(ManualMode.class);
+    }
+
+    @After
+    public void stop() throws Exception {
+        if (controller.isStarted(PRIMARY_CONTAINER)) {
+            controller.stop(PRIMARY_CONTAINER);
+        }
+        if (controller.isStarted(SECONDARY_CONTAINER)) {
+            controller.stop(SECONDARY_CONTAINER);
+        }
+    }
+
+    @Test
+    public void testServerControl() throws Exception {
+        // The primary container should already be started
+        controller.start(PRIMARY_CONTAINER);
+        Assert.assertTrue(String.format("The container \"%s\" should be started", PRIMARY_CONTAINER), controller.isStarted(PRIMARY_CONTAINER));
+        controller.stop(PRIMARY_CONTAINER);
+        Assert.assertFalse(String.format("The container \"%s\" should be stopped", PRIMARY_CONTAINER), controller.isStarted(PRIMARY_CONTAINER));
+
+        // Start and stop the secondary controller
+        controller.start(SECONDARY_CONTAINER);
+        Assert.assertTrue(String.format("The container \"%s\" should be started", SECONDARY_CONTAINER), controller.isStarted(SECONDARY_CONTAINER));
+        controller.stop(SECONDARY_CONTAINER);
+        Assert.assertFalse(String.format("The container \"%s\" should be stopped", SECONDARY_CONTAINER), controller.isStarted(SECONDARY_CONTAINER));
+    }
+
+    @Test
+    public void testManagementClient() throws Exception {
+        controller.start(PRIMARY_CONTAINER);
+        executeForSuccess(primaryClient, Operations.createReadAttributeOperation(EMPTY_ADDRESS, "server-state"));
+        controller.stop(PRIMARY_CONTAINER);
+        controller.start(SECONDARY_CONTAINER);
+        executeForSuccess(secondaryClient, Operations.createReadAttributeOperation(EMPTY_ADDRESS, "server-state"));
+        controller.stop(SECONDARY_CONTAINER);
+    }
+
+    static ModelNode executeForSuccess(final ManagementClient client, final ModelNode op) throws IOException {
+        return executeForSuccess(client, Operation.Factory.create(op));
+    }
+
+    static ModelNode executeForSuccess(final ManagementClient client, final Operation op) throws IOException {
+        final ModelNode result = client.getControllerClient().execute(op);
+        if (Operations.isSuccessfulOutcome(result)) {
+            return Operations.readResult(result);
+        }
+        Assert.fail(String.format("Failed to execute operation: %s%n%s", op, Operations.getFailureDescription(result).asString()));
+        return new ModelNode();
+    }
+
+    static int getCurrentDeploymentCount(final ManagementClient client) throws IOException {
+        final ModelNode op = Operations.createOperation(ClientConstants.READ_CHILDREN_NAMES_OPERATION, EMPTY_ADDRESS);
+        op.get(ClientConstants.CHILD_TYPE).set(ClientConstants.DEPLOYMENT);
+        return executeForSuccess(client, op).asList().size();
+    }
+
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/manual/ClientManualModeTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/manual/ClientManualModeTestCase.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed.manual;
+
+import java.io.IOException;
+
+import org.jboss.arquillian.container.spi.client.container.DeploymentException;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ArchiveDeployer;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that the injected management client and archive deployer are usable on the appropriate container.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ClientManualModeTestCase extends AbstractManualModeTestCase {
+
+    @ArquillianResource
+    @TargetsContainer(PRIMARY_CONTAINER)
+    private ArchiveDeployer primaryDeployer;
+
+    @ArquillianResource
+    @TargetsContainer(SECONDARY_CONTAINER)
+    private ArchiveDeployer secondaryDeployer;
+
+    @Test
+    public void testDeploy() throws Exception {
+        testDeploy(primaryDeployer, primaryClient, PRIMARY_CONTAINER);
+        testDeploy(secondaryDeployer, secondaryClient, SECONDARY_CONTAINER);
+    }
+
+    private static void testDeploy(final ArchiveDeployer deployer, final ManagementClient client, final String containerName) throws IOException, DeploymentException {
+        if (!controller.isStarted(containerName)) {
+            controller.start(containerName);
+        }
+        final int currentDeployments = getCurrentDeploymentCount(client);
+        // Deploy both deployments
+        try {
+            deployer.deploy(createDeployment());
+            // Read each result, we should have two results for the first op and one for the second
+            final int newDeployments = getCurrentDeploymentCount(client);
+            Assert.assertTrue("Expected 1 deployments found " + (newDeployments - currentDeployments) + " for container " + containerName,
+                    newDeployments == (1 + currentDeployments));
+        } finally {
+            deployer.undeploy("dep1");
+            controller.stop(containerName);
+        }
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/manual/InContainerManualModeTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/manual/InContainerManualModeTestCase.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed.manual;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+public class InContainerManualModeTestCase extends AbstractManualModeTestCase {
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/manual/ManualMode.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/manual/ManualMode.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container.managed.manual;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public interface ManualMode {
+}

--- a/container-bootable/src/test/resources/arquillian.xml
+++ b/container-bootable/src/test/resources/arquillian.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <defaultProtocol type="jmx-as7">
+        <property name="enableThreadContextClassLoader">false</property>
+    </defaultProtocol>
+
+    <container qualifier="jboss" default="true">
+        <configuration>
+            <property name="installDir">${install.dir}</property>
+            <property name="jarFile">${bootable.jar}</property>
+            <property name="jbossArguments">-Dorg.jboss.as.arquillian.container.managed.prop1=prop1 -Dorg.jboss.as.arquillian.container.managed.prop2=prop2</property>
+            <property name="javaVmArguments">${jvm.args}</property>
+            
+            <!--
+                 Please leave this as false. It is a good, early catch for the reviewers to make
+                 sure that they have not left a stale server running when merging pull requests
+            -->
+            <property name="allowConnectingToRunningServer">false</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/container-bootable/src/test/resources/logging.properties
+++ b/container-bootable/src/test/resources/logging.properties
@@ -1,0 +1,46 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Additional logger names to configure (root logger is always configured)
+loggers=sun.rmi,org.jboss.shrinkwrap
+logger.org.jboss.shrinkwrap.level=INFO
+logger.sun.rmi.level=WARNING
+
+# Root logger level
+logger.level=DEBUG
+
+# Root logger handlers
+logger.handlers=FILE, CONSOLE
+
+# Console handler configuration
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.properties=autoFlush
+handler.CONSOLE.level=INFO
+handler.CONSOLE.autoFlush=true
+handler.CONSOLE.formatter=PATTERN
+
+# File handler configuration
+handler.FILE=org.jboss.logmanager.handlers.FileHandler
+handler.FILE.level=DEBUG
+handler.FILE.properties=autoFlush,fileName
+handler.FILE.autoFlush=true
+handler.FILE.fileName=./target/test.log
+handler.FILE.formatter=PATTERN
+
+# Formatter pattern configuration
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n

--- a/container-bootable/src/test/resources/manual-arquillian.xml
+++ b/container-bootable/src/test/resources/manual-arquillian.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <group qualifier="wildfly" default="true">
+        <container qualifier="jboss" default="true" mode="manual">
+            <configuration>
+                <property name="installDir">${install.dir}</property>
+                <property name="jarFile">${bootable.jar}</property>
+                <property name="allowConnectingToRunningServer">false</property>
+                <property name="javaVmArguments">${jvm.args}</property>
+            </configuration>
+        </container>
+        <container qualifier="wildfly" default="false" mode="manual">
+            <configuration>
+                <property name="installDir">${install.dir}</property>
+                <property name="jarFile">${bootable.jar}</property>
+                <property name="allowConnectingToRunningServer">false</property>
+                <!-- Change the management port to ensure only the correct client will work with the server -->
+                <property name="managementPort">9999</property>
+                <property name="jbossArguments">-Djboss.management.http.port=9999</property>
+                <property name="javaVmArguments">${jvm.args}</property>
+            </configuration>
+        </container>
+    </group>
+</arquillian>

--- a/container-bootable/src/test/resources/sar-example.sar/META-INF/jboss-service.xml
+++ b/container-bootable/src/test/resources/sar-example.sar/META-INF/jboss-service.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2015 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<server xmlns="urn:jboss:service:7.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:service:7.0 jboss-service_7_0.xsd">
+
+    <mbean name="jboss:name=test,type=config" code="org.jboss.as.arquillian.container.managed.archive.ConfigService">
+        <attribute name="intervalSeconds">1</attribute>
+    </mbean>
+</server>

--- a/container-bootable/src/test/resources/testfile.properties
+++ b/container-bootable/src/test/resources/testfile.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.jboss.as.arquillian.container.managed.prop1=prop1
+org.jboss.as.arquillian.container.managed.prop2=prop2

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,8 @@
 
         <!-- Other properties -->
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-        <jvm.args>-Dmaven.repo.local=${settings.localRepository}</jvm.args>
+        <default.jvm.args>-Dmaven.repo.local=${settings.localRepository}</default.jvm.args>
+        <jvm.args>${default.jvm.args}</jvm.args>
         <wildfly.standalone.config>standalone.xml</wildfly.standalone.config>
     </properties>
 
@@ -455,6 +456,21 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>skip-log-manager-check</id>
+            <activation>
+                <property>
+                    <name>org.wildfly.logging.skipLogManagerCheck</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- Skip the log manager validation in the logging subsystem -->
+                <jvm.args>${default.jvm.args} -Dorg.wildfly.logging.skipLogManagerCheck=true</jvm.args>
+            </properties>
+        </profile>
+    </profiles>
 
     <dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <name>WildFly: Arquillian</name>
 
     <properties>
-        <version.org.wildfly.core>11.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>13.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.full>15.0.1.Final</version.org.wildfly.full>
         <version.junit>4.12</version.junit>
         <version.org.jboss.arquillian.core>1.6.0.Final</version.org.jboss.arquillian.core>
@@ -158,6 +158,7 @@
     </build>
     <modules>
         <module>common</module>
+        <module>container-bootable</module>
         <module>container-embedded</module>
         <module>container-managed</module>
         <module>container-remote</module>
@@ -179,6 +180,11 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.wildfly.arquillian</groupId>
+                <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.wildfly.arquillian</groupId>
                 <artifactId>wildfly-arquillian-container-embedded</artifactId>


### PR DESCRIPTION
Replaces #165 

Issue: https://issues.redhat.com/browse/WFARQ-65

* New Bootable JAR container
* Copied tests from managed container. Ignored Testcase related to sar (not present in standalone-microprofile.xml).
* Bootable JAR for tests is provisioned using 2.0.0.Beta1. Would need to be upgrade to GA.
* WildFly 20 is provisioned for tests.
