### PR TITLE
[WFARQ-72] Configure the maven-javadoc-plugin to work with Java 11 an…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,17 @@
         </testResources>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <!-- Using this doesn't require the JAVA_HOME to be set -->
+                        <javadocExecutable>${java.home}${file.separator}bin</javadocExecutable>
+                        <!-- Set the source to 8 as that is the target, but allows this to be compiled with new versions
+                             of Java.
+                         -->
+                        <source>8</source>
+                    </configuration>
+                </plugin>
                 <!-- Checkstyle -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
…d if the JAVA_HOME environment variable is not set.

https://issues.redhat.com/browse/WFARQ-72