### PR TITLE
Revert "A couple of JBoss MSC API deprecation fixes"

### DIFF
--- a/container-embedded/src/test/java/org/jboss/as/arquillian/container/embedded/SystemPropertyServiceActivator.java
+++ b/container-embedded/src/test/java/org/jboss/as/arquillian/container/embedded/SystemPropertyServiceActivator.java
@@ -16,36 +16,40 @@
 
 package org.jboss.as.arquillian.container.embedded;
 
-import org.jboss.msc.Service;
+import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceActivator;
 import org.jboss.msc.service.ServiceActivatorContext;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistryException;
 import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 
 /**
  * @author Stuart Douglas
- * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
-public final class SystemPropertyServiceActivator implements ServiceActivator {
+public class SystemPropertyServiceActivator implements ServiceActivator {
 
-    static final String TEST_PROPERTY = "test-property";
-    static final String VALUE = "set";
+    public static final String TEST_PROPERTY = "test-property";
+    public static final String VALUE = "set";
 
     @Override
-    public void activate(final ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
-        serviceActivatorContext.getServiceTarget().addService(ServiceName.of("test-service")).setInstance(new Service() {
+    public void activate(ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
+        serviceActivatorContext.getServiceTarget().addService(ServiceName.of("test-service"), new Service<Object>() {
             @Override
-            public void start(final StartContext context) {
+            public void start(StartContext context) throws StartException {
                 System.setProperty(TEST_PROPERTY, VALUE);
             }
 
             @Override
-            public void stop(final StopContext context) {
+            public void stop(StopContext context) {
                 System.clearProperty(TEST_PROPERTY);
+            }
+
+            @Override
+            public Object getValue() throws IllegalStateException, IllegalArgumentException {
+                return this;
             }
         }).install();
     }
-
 }

--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/SystemPropertyServiceActivator.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/SystemPropertyServiceActivator.java
@@ -16,36 +16,40 @@
 
 package org.jboss.as.arquillian.container.managed;
 
-import org.jboss.msc.Service;
+import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceActivator;
 import org.jboss.msc.service.ServiceActivatorContext;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistryException;
 import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 
 /**
  * @author Stuart Douglas
- * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
-public final class SystemPropertyServiceActivator implements ServiceActivator {
+public class SystemPropertyServiceActivator implements ServiceActivator {
 
-    static final String TEST_PROPERTY = "test-property";
-    static final String VALUE = "set";
+    public static final String TEST_PROPERTY = "test-property";
+    public static final String VALUE = "set";
 
     @Override
-    public void activate(final ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
-        serviceActivatorContext.getServiceTarget().addService(ServiceName.of("test-service")).setInstance(new Service() {
+    public void activate(ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
+        serviceActivatorContext.getServiceTarget().addService(ServiceName.of("test-service"), new Service<Object>() {
             @Override
-            public void start(final StartContext context) {
+            public void start(StartContext context) throws StartException {
                 System.setProperty(TEST_PROPERTY, VALUE);
             }
 
             @Override
-            public void stop(final StopContext context) {
+            public void stop(StopContext context) {
                 System.clearProperty(TEST_PROPERTY);
+            }
+
+            @Override
+            public Object getValue() throws IllegalStateException, IllegalArgumentException {
+                return this;
             }
         }).install();
     }
-
 }

--- a/protocol-jmx/src/main/java/org/jboss/as/arquillian/service/ArquillianConfigBuilder.java
+++ b/protocol-jmx/src/main/java/org/jboss/as/arquillian/service/ArquillianConfigBuilder.java
@@ -58,16 +58,23 @@ class ArquillianConfigBuilder {
     ArquillianConfigBuilder() {
     }
 
-    static Set<String> getClasses(final DeploymentUnit depUnit) {
+    static ArquillianConfig processDeployment(DeploymentUnit depUnit) {
+
         // Get Test Class Names
         final Set<String> testClasses = depUnit.getAttachment(CLASSES);
-        return testClasses == null || testClasses.isEmpty() ? null : testClasses;
+
+        // No tests found
+        if (testClasses == null || testClasses.isEmpty()) {
+            return null;
+        }
+
+        return new ArquillianConfig(testClasses, createDeploymentUnitName(depUnit));
     }
 
-    static String getName(final DeploymentUnit depUnit) {
+    private static String createDeploymentUnitName(DeploymentUnit depUnit) {
         String depUnitName = depUnit.getName();
         DeploymentUnit parent;
-        if ((parent = depUnit.getParent()) != null) {
+        if((parent = depUnit.getParent()) != null) {
             depUnitName = parent.getName() + "." + depUnitName;
         }
         return depUnitName;

--- a/protocol-jmx/src/main/java/org/jboss/as/arquillian/service/ArquillianService.java
+++ b/protocol-jmx/src/main/java/org/jboss/as/arquillian/service/ArquillianService.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
-import java.util.function.Consumer;
 import javax.management.MBeanServer;
 
 import org.jboss.arquillian.container.test.spi.TestRunner;
@@ -36,9 +34,8 @@ import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.Phase;
 import org.jboss.logging.Logger;
 import org.jboss.modules.Module;
-import org.jboss.msc.Service;
-import org.jboss.msc.service.LifecycleEvent;
-import org.jboss.msc.service.LifecycleListener;
+import org.jboss.msc.service.AbstractServiceListener;
+import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
@@ -46,46 +43,41 @@ import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * Service responsible for creating and managing the life-cycle of the Arquillian service.
  *
+ *
  * @author Thomas.Diesler@jboss.com
  * @author Kabir Khan
- * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ * @since 17-Nov-2010
  */
-public class ArquillianService implements Service {
+public class ArquillianService implements Service<ArquillianService> {
 
     public static final String TEST_CLASS_PROPERTY = "org.jboss.as.arquillian.testClass";
     public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("arquillian", "testrunner");
+
     private static final Logger log = Logger.getLogger("org.jboss.as.arquillian");
 
-    private final Supplier<MBeanServer> mBeanServerSupplier;
-    private final Consumer<ArquillianService> arquillianServiceConsumer;
+    private final InjectedValue<MBeanServer> injectedMBeanServer = new InjectedValue<MBeanServer>();
     private final Set<ArquillianConfig> deployedTests = new HashSet<>();
     private volatile JMXTestRunner jmxTestRunner;
-    private volatile LifecycleListener listener;
-
-    private ArquillianService(final Supplier<MBeanServer> mBeanServerSupplier, final Consumer<ArquillianService> arquillianServiceConsumer) {
-        this.mBeanServerSupplier = mBeanServerSupplier;
-        this.arquillianServiceConsumer = arquillianServiceConsumer;
-    }
+    private volatile AbstractServiceListener<Object> listener;
 
     public static void addService(final ServiceTarget serviceTarget) {
-        ServiceBuilder<?> builder = serviceTarget.addService(ArquillianService.SERVICE_NAME);
-        builder.setInstance(new ArquillianService(
-                builder.requires(MBeanServerService.SERVICE_NAME),
-                builder.provides(ArquillianService.SERVICE_NAME)
-        ));
+        ArquillianService service = new ArquillianService();
+        ServiceBuilder<?> builder = serviceTarget.addService(ArquillianService.SERVICE_NAME, service);
+        builder.addDependency(MBeanServerService.SERVICE_NAME, MBeanServer.class, service.injectedMBeanServer);
+        builder.setInitialMode(ServiceController.Mode.ACTIVE);
         builder.install();
     }
 
-    public synchronized void start(final StartContext context) throws StartException {
+    public synchronized void start(StartContext context) throws StartException {
         log.debugf("Starting Arquillian Test Runner");
 
-        arquillianServiceConsumer.accept(this);
-        final MBeanServer mbeanServer = mBeanServerSupplier.get();
+        final MBeanServer mbeanServer = injectedMBeanServer.getValue();
         try {
             jmxTestRunner = new ExtendedJMXTestRunner();
             jmxTestRunner.registerMBean(mbeanServer);
@@ -93,25 +85,30 @@ public class ArquillianService implements Service {
             throw new StartException("Failed to start Arquillian Test Runner", t);
         }
 
-        listener = new ArquillianListener(context.getChildTarget());
+        listener = new ArquillianServiceListener(context.getChildTarget());
         context.getController().getServiceContainer().addListener(listener);
     }
 
-    public synchronized void stop(final StopContext context) {
+    public synchronized void stop(StopContext context) {
         log.debugf("Stopping Arquillian Test Runner");
-
         try {
             if (jmxTestRunner != null) {
-                jmxTestRunner.unregisterMBean(mBeanServerSupplier.get());
+                jmxTestRunner.unregisterMBean(injectedMBeanServer.getValue());
             }
         } catch (Exception ex) {
             log.errorf(ex, "Cannot stop Arquillian Test Runner");
-        }
+        } finally {
+            context.getController().getServiceContainer().removeListener(listener);
 
-        context.getController().getServiceContainer().removeListener(listener);
+        }
     }
 
-    void registerArquillianConfig(final ArquillianConfig arqConfig) {
+    @Override
+    public synchronized ArquillianService getValue() throws IllegalStateException {
+        return this;
+    }
+
+    void registerArquillianConfig(ArquillianConfig arqConfig) {
         synchronized (deployedTests) {
             log.debugf("Register Arquillian config: %s", arqConfig.getServiceName());
             deployedTests.add(arqConfig);
@@ -119,15 +116,16 @@ public class ArquillianService implements Service {
         }
     }
 
-    void unregisterArquillianConfig(final ArquillianConfig arqConfig) {
+    void unregisterArquillianConfig(ArquillianConfig arqConfig) {
         synchronized (deployedTests) {
             log.debugf("Unregister Arquillian config: %s", arqConfig.getServiceName());
             deployedTests.remove(arqConfig);
         }
     }
 
-    private ArquillianConfig getArquillianConfig(final String className, final long timeout) {
+    private ArquillianConfig getArquillianConfig(final String className, long timeout) {
         synchronized (deployedTests) {
+
             log.debugf("Getting Arquillian config for: %s", className);
             for (ArquillianConfig arqConfig : deployedTests) {
                 for (String aux : arqConfig.getTestClasses()) {
@@ -152,7 +150,7 @@ public class ArquillianService implements Service {
         return getArquillianConfig(className, -1);
     }
 
-    private class ExtendedJMXTestRunner extends JMXTestRunner {
+    class ExtendedJMXTestRunner extends JMXTestRunner {
 
         ExtendedJMXTestRunner() {
             super(new ExtendedTestClassLoader());
@@ -167,7 +165,7 @@ public class ArquillianService implements Service {
             try {
                 ClassLoader runWithClassLoader = ClassLoader.getSystemClassLoader();
                 if (Boolean.parseBoolean(protocolProps.get(ExtendedJMXProtocolConfiguration.PROPERTY_ENABLE_TCCL))) {
-                    DeploymentUnit depUnit = config.getDeploymentUnit();
+                    DeploymentUnit depUnit = config.getDeploymentUnit().getValue();
                     Module module = depUnit.getAttachment(Attachments.MODULE);
                     if (module != null) {
                         runWithClassLoader = module.getClassLoader();
@@ -191,7 +189,7 @@ public class ArquillianService implements Service {
             ClassLoader runWithClassLoader = ClassLoader.getSystemClassLoader();
             if (Boolean.parseBoolean(protocolProps.get(ExtendedJMXProtocolConfiguration.PROPERTY_ENABLE_TCCL))) {
                 ArquillianConfig config = getArquillianConfig(testClass.getName(), 30000L);
-                DeploymentUnit depUnit = config.getDeploymentUnit();
+                DeploymentUnit depUnit = config.getDeploymentUnit().getValue();
                 Module module = depUnit.getAttachment(Attachments.MODULE);
                 if (module != null) {
                     runWithClassLoader = module.getClassLoader();
@@ -207,7 +205,7 @@ public class ArquillianService implements Service {
 
         private ContextManager setupContextManager(final ArquillianConfig config, final Map<String, Object> properties) {
             try {
-                final DeploymentUnit depUnit = config.getDeploymentUnit();
+                final DeploymentUnit depUnit = config.getDeploymentUnit().getValue();
                 final ContextManagerBuilder builder = new ContextManagerBuilder(config).addAll(depUnit);
                 ContextManager contextManager = builder.build();
                 contextManager.setup(properties);
@@ -231,45 +229,47 @@ public class ArquillianService implements Service {
         }
     }
 
-    // TODO: This listener based solution is still too hacky. Proper integration should be:
-    // TODO: 1) either parentController service will expose DU retrieval via public method
-    // TODO: 2) or this listener based solution will be replaced with WildFly Extension based solution
-    private static class ArquillianListener implements LifecycleListener {
-        private final ServiceTarget serviceTarget;
+    private static class ArquillianServiceListener extends AbstractServiceListener<Object> {
+        private ServiceTarget serviceTarget;
 
-        private ArquillianListener(final ServiceTarget serviceTarget) {
+        private ArquillianServiceListener(ServiceTarget serviceTarget) {
             this.serviceTarget = serviceTarget;
         }
 
         @Override
-        public void handleEvent(final ServiceController<?> controller, final LifecycleEvent event) {
-            if (event != LifecycleEvent.UP) return;
-            ServiceName serviceName = controller.getName();
-            if (!JBOSS_DEPLOYMENT.isParentOf(serviceName)) return;
-
-            String simpleName = serviceName.getSimpleName();
-            if (simpleName.equals(Phase.DEPENDENCIES.toString())) {
-                ServiceName parentName = serviceName.getParent();
-                ServiceController<?> parentController = controller.getServiceContainer().getService(parentName);
-                DeploymentUnit depUnit = (DeploymentUnit) parentController.getValue(); // TODO: eliminate deprecated API usage
-                ArquillianConfigBuilder.handleParseAnnotations(depUnit);
-            } else if (simpleName.equals(Phase.INSTALL.toString())) {
-                ServiceName parentName = serviceName.getParent();
-                ServiceController<?> parentController = controller.getServiceContainer().getService(parentName);
-                DeploymentUnit depUnit = (DeploymentUnit) parentController.getValue(); // TODO: eliminate deprecated API usage
-                Set<String> testClasses = ArquillianConfigBuilder.getClasses(depUnit);
-                if (testClasses != null) {
-                    String duName = ArquillianConfigBuilder.getName(depUnit);
-                    ServiceName arqConfigSN = ServiceName.JBOSS.append("arquillian", "config", duName);
-                    ServiceBuilder<ArquillianConfig> builder = (ServiceBuilder<ArquillianConfig>) serviceTarget.addService(arqConfigSN);
-                    ArquillianConfig arqConfig = new ArquillianConfig(arqConfigSN, testClasses,
-                            builder.requires(ArquillianService.SERVICE_NAME),
-                            builder.requires(parentController.getName()));
-                    arqConfig.addDeps(builder, controller);
-                    builder.setInstance(arqConfig);
-                    builder.install();
-                    log.infof("Arquillian deployment detected: %s", arqConfig);
+        public void transition(ServiceController<? extends Object> serviceController, ServiceController.Transition transition) {
+            switch (transition.getAfter()) {
+                case UP: {
+                    ServiceName serviceName = serviceController.getName();
+                    String simpleName = serviceName.getSimpleName();
+                    if (JBOSS_DEPLOYMENT.isParentOf(serviceName) && simpleName.equals(Phase.INSTALL.toString())) {
+                        ServiceName parentName = serviceName.getParent();
+                        ServiceController<?> parentController = serviceController.getServiceContainer().getService(parentName);
+                        DeploymentUnit depUnit = (DeploymentUnit) parentController.getValue();
+                        ArquillianConfig arqConfig = ArquillianConfigBuilder.processDeployment(depUnit);
+                        if (arqConfig != null) {
+                            log.infof("Arquillian deployment detected: %s", arqConfig);
+                            ServiceBuilder<ArquillianConfig> builder = serviceTarget.addService(arqConfig.getServiceName(), arqConfig)
+                                    .addDependency(ArquillianService.SERVICE_NAME, ArquillianService.class, arqConfig.getArquillianService())
+                                    .addDependency(parentController.getName(), DeploymentUnit.class, arqConfig.getDeploymentUnit());
+                            arqConfig.addDeps(builder, serviceController);
+                            builder.setInitialMode(ServiceController.Mode.ACTIVE);
+                            builder.install();
+                        }
+                    }
                 }
+                break;
+                case STARTING: {
+                    ServiceName serviceName = serviceController.getName();
+                    String simpleName = serviceName.getSimpleName();
+                    if(JBOSS_DEPLOYMENT.isParentOf(serviceName) && simpleName.equals(Phase.DEPENDENCIES.toString())) {
+                        ServiceName parentName = serviceName.getParent();
+                        ServiceController<?> parentController = serviceController.getServiceContainer().getService(parentName);
+                        DeploymentUnit depUnit = (DeploymentUnit) parentController.getValue();
+                        ArquillianConfigBuilder.handleParseAnnotations(depUnit);
+                    }
+                }
+                break;
             }
         }
     }

--- a/protocol-jmx/src/main/java/org/jboss/as/arquillian/service/ContextManager.java
+++ b/protocol-jmx/src/main/java/org/jboss/as/arquillian/service/ContextManager.java
@@ -60,7 +60,7 @@ public class ContextManager {
      */
     public void setup(final Map<String, Object> properties) {
         final List<SetupAction> successfulActions = new ArrayList<SetupAction>();
-        final DeploymentUnit depUnit = config.getDeploymentUnit();
+        final DeploymentUnit depUnit = config.getDeploymentUnit().getValue();
         final Module module = depUnit.getAttachment(Attachments.MODULE);
         ClassLoader tccl = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(module.getClassLoader());
         try {
@@ -96,7 +96,7 @@ public class ContextManager {
     public void teardown(final Map<String, Object> properties) {
         Throwable exceptionToThrow = null;
         final ListIterator<SetupAction> itr = setupActions.listIterator(setupActions.size());
-        final DeploymentUnit depUnit = config.getDeploymentUnit();
+        final DeploymentUnit depUnit = config.getDeploymentUnit().getValue();
         final Module module = depUnit.getAttachment(Attachments.MODULE);
         ClassLoader tccl = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(module.getClassLoader());
         try {


### PR DESCRIPTION
Reverts wildfly/wildfly-arquillian#140

See https://issues.redhat.com/browse/WFARQ-84 for details. I think we need to take a better look at this as it's causing failures in WildFly. WildFly itself has downgraded back to WFARQ 2.2, https://github.com/wildfly/wildfly/pull/13636.