### PR TITLE
[WFARQ-31] Allow a socket-binding-group name to be defined via config…

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerConfiguration.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerConfiguration.java
@@ -35,8 +35,11 @@ public class CommonContainerConfiguration implements ContainerConfiguration {
     private String username;
     private String password;
     private String authenticationConfig;
+
+    private String protocol = "http";
     private String host;
     private int port;
+    private String socketBindingGroup;
 
     /**
      * Optional connection timeout in millis.
@@ -84,6 +87,36 @@ public class CommonContainerConfiguration implements ContainerConfiguration {
 
     public String getManagementProtocol() {
         return managementProtocol;
+    }
+
+    /**
+     * Returns the protocol to for HTTP connections. This currently only supports http and https with a default of http.
+     *
+     * @return the protocol
+     */
+    public String getProtocol() {
+        return protocol;
+    }
+
+    /**
+     * Sets the protocol for HTTP connections. If {@code null} the default of http is used.
+     *
+     * @param protocol the protocol to use, this must be http or https
+     */
+    public void setProtocol(final String protocol) {
+        this.protocol = protocol == null ? "http" : protocol;
+        if (!("http".equalsIgnoreCase(this.protocol) || "https".equalsIgnoreCase(this.protocol))) {
+            throw new ConfigurationException("Only http and https are allowed protocol settings, found " + protocol);
+        }
+    }
+
+    /**
+     * Returns the socket binding name to use.
+     *
+     * @return the socket binding name or {@code null} to discover one
+     */
+    public String getSocketBindingGroup() {
+        return socketBindingGroup;
     }
 
     public String getHost() {
@@ -138,10 +171,27 @@ public class CommonContainerConfiguration implements ContainerConfiguration {
         this.authenticationConfig = authenticationConfig;
     }
 
+    /**
+     * Sets the socket binding name to use for determining the host and port for HTTP connections. This can be used to
+     * override discovering the first binding name.
+     * <p>
+     * The socket binding name is configured in WildFly. If this is not set, one will be determined from the Undertow
+     * subsystem.
+     * </p>
+     *
+     * @param socketBindingName the socket binding name or {@code null} for one to be determined
+     */
+    public void setSocketBindingGroup(final String socketBindingName) {
+        this.socketBindingGroup = socketBindingName;
+    }
+
     @Override
     public void validate() throws ConfigurationException {
         if (username != null && password == null) {
             throw new ConfigurationException("username has been set, but no password given");
+        }
+        if (protocol != null && !("http".equalsIgnoreCase(protocol) || "https".equalsIgnoreCase(protocol))) {
+            throw new ConfigurationException("Only http and https are allowed protocol settings, found " + protocol);
         }
     }
 }

--- a/integration-tests/junit5-tests/pom.xml
+++ b/integration-tests/junit5-tests/pom.xml
@@ -103,6 +103,29 @@
                         <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
                     </environmentVariables>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <groups>!OverrideWebUri</groups>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>override-web-uri</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <groups>OverrideWebUri</groups>
+                            <systemPropertyVariables>
+                                <arquillian.xml>override-web-uri-arquillian.xml</arquillian.xml>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/config/AbstractOverrideWebUriTest.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/config/AbstractOverrideWebUriTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.config;
+
+import java.net.URI;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ExtendWith(ArquillianExtension.class)
+@Tag("OverrideWebUri")
+abstract class AbstractOverrideWebUriTest {
+
+    @ArquillianResource
+    protected URL url;
+
+    @ArquillianResource
+    private URI uri;
+
+    @ArquillianResource
+    private ManagementClient client;
+
+    @Test
+    public void url() {
+        Assertions.assertNotNull(url, "URL was null and not injected");
+        testUrl(url);
+    }
+
+    @Test
+    @RunAsClient
+    public void urlClient() {
+        Assertions.assertNotNull(url, "URL was null and not injected");
+        testUrl(url);
+    }
+
+    @Test
+    public void uri() {
+        Assertions.assertNotNull(uri, "URI was null and not injected");
+        testUri(uri);
+    }
+
+    @Test
+    @RunAsClient
+    public void uriClient() {
+        Assertions.assertNotNull(uri, "URI was null and not injected");
+        testUri(uri);
+    }
+
+    @Test
+    public void managementClient() {
+        Assertions.assertNotNull(client, "The ManagementClient is null nad was not injected");
+        final URI uri = client.getWebUri();
+        Assertions.assertNotNull(uri, "Could not determine the URI from the management client");
+        testUri(uri);
+    }
+
+    @Test
+    @RunAsClient
+    public void managementClientAsClient() {
+        Assertions.assertNotNull(client, "The ManagementClient is null nad was not injected");
+        final URI uri = client.getWebUri();
+        Assertions.assertNotNull(uri, "Could not determine the URI from the management client");
+        testUri(uri);
+    }
+
+    private static void testUrl(final URL url) {
+        Assertions.assertEquals("https", url.getProtocol());
+        Assertions.assertEquals("127.0.0.1", url.getHost());
+        Assertions.assertEquals(8443, url.getPort());
+    }
+
+    private static void testUri(final URI uri) {
+        Assertions.assertEquals("https", uri.getScheme());
+        Assertions.assertEquals("127.0.0.1", uri.getHost());
+        Assertions.assertEquals(8443, uri.getPort());
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/config/EarClientOverrideWebUriTestCase.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/config/EarClientOverrideWebUriTestCase.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.config;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class EarClientOverrideWebUriTestCase extends AbstractOverrideWebUriTest {
+
+    @Deployment(testable = false)
+    public static EnterpriseArchive deployment() {
+        return ShrinkWrap.create(EnterpriseArchive.class, EarClientOverrideWebUriTestCase.class.getSimpleName() + ".ear")
+                .addAsModule(
+                        ShrinkWrap.create(WebArchive.class, EarClientOverrideWebUriTestCase.class.getSimpleName() + "-war.war")
+                                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                );
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/config/JarClientOverrideWebUriTestCase.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/config/JarClientOverrideWebUriTestCase.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.config;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class JarClientOverrideWebUriTestCase extends AbstractOverrideWebUriTest {
+
+    @Deployment(testable = false)
+    public static JavaArchive deployment() {
+        return ShrinkWrap.create(JavaArchive.class, JarClientOverrideWebUriTestCase.class.getSimpleName() + ".war")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/config/WarClientOverrideWebUriTestCase.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/config/WarClientOverrideWebUriTestCase.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.config;
+
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.wildfly.arquillian.integration.test.junit5.GreeterServlet;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class WarClientOverrideWebUriTestCase extends AbstractOverrideWebUriTest {
+
+    private static final X509TrustManager TRUST_ALL = new X509TrustManager() {
+        @Override
+        public void checkClientTrusted(final X509Certificate[] chain, final String authType) {
+        }
+
+        @Override
+        public void checkServerTrusted(final X509Certificate[] chain, final String authType) {
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    };
+
+    @Deployment(testable = false)
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class, WarClientOverrideWebUriTestCase.class.getSimpleName() + ".war")
+                .addClass(GreeterServlet.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    @RunAsClient
+    public void httpsConnection() throws Exception {
+        final SSLContext sslContext = SSLContext.getInstance("SSL");
+        sslContext.init(null, new TrustManager[] {TRUST_ALL}, new SecureRandom());
+        final OkHttpClient client = new OkHttpClient.Builder()
+                .readTimeout(5, TimeUnit.SECONDS)
+                .hostnameVerifier((hostname, session) -> true)
+                .sslSocketFactory(sslContext.getSocketFactory(), TRUST_ALL)
+                .build();
+        final Request request = new Request.Builder()
+                .url(url + GreeterServlet.URL_PATTERN)
+                .build();
+        final Call call = client.newCall(request);
+        try (final Response response = call.execute()) {
+            Assertions.assertEquals(200, response.code());
+            final ResponseBody body = response.body();
+            Assertions.assertNotNull(body);
+            Assertions.assertEquals(GreeterServlet.GREETING, body.string());
+        }
+    }
+}

--- a/integration-tests/junit5-tests/src/test/resources/override-web-uri-arquillian.xml
+++ b/integration-tests/junit5-tests/src/test/resources/override-web-uri-arquillian.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="jboss" default="true">
+        <configuration>
+            <property name="jbossHome">${jboss.home}</property>
+            <property name="javaVmArguments">${debug.vm.args} ${jvm.args}</property>
+            <property name="allowConnectingToRunningServer">false</property>
+            <property name="protocol">https</property>
+            <property name="socketBindingGroup">https</property>
+        </configuration>
+    </container>
+</arquillian>


### PR DESCRIPTION
…uration. Allowing this, it also made sense to allow the protocol to be overridden for things like https connections.

https://issues.redhat.com/browse/WFARQ-31
Signed-off-by: James R. Perkins <jperkins@redhat.com>