### PR TITLE
[WFARQ-124] Require a minimum of Java 11 for runtime.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest ]
-        java: ['8', '11', '17']
+        java: ['11', '17']
 
     steps:
       - uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
 
         <!-- Build minimums -->
         <maven.min.version>3.6.0</maven.min.version>
+
+        <!-- Require at least Java 11 to compile -->
+        <jdk.min.version>11</jdk.min.version>
+        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
     </properties>
 
     <licenses>
@@ -120,10 +126,8 @@
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
-                        <!-- Set the source to 8 as that is the target, but allows this to be compiled with new versions
-                             of Java.
-                         -->
-                        <source>8</source>
+                        <release>${maven.compiler.release}</release>
+                        <additionalJOption>--no-module-directories</additionalJOption>
                     </configuration>
                 </plugin>
                 <!-- Checkstyle -->


### PR DESCRIPTION
https://issues.redhat.com/browse/WFARQ-124
Signed-off-by: James R. Perkins <jperkins@redhat.com>