### PR TITLE
Add system property for setting read only server config

### DIFF
--- a/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
+++ b/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
@@ -32,7 +32,7 @@ public class ManagedContainerConfiguration extends DistributionContainerConfigur
 
     private String serverConfig = System.getProperty("jboss.server.config.file.name");
 
-    private String readOnlyServerConfig;
+    private String readOnlyServerConfig = System.getProperty("jboss.server.config.file.name.readonly");
 
     private boolean enableAssertions = true;
 


### PR DESCRIPTION
After this change to Wildfly core

https://github.com/wildfly/wildfly-core/commit/a958b5e1f000b4db8b8da2ec38e85fe850a0d9ec

Driven by this issue

https://issues.redhat.com/browse/WFCORE-5792

A server config file that is stored outside of the managed Wildfly server's configuration directory can no longer be provided via the jboss.server.config.file.name system property.  A read-only server config must be used if the config file is outside the configuration directory.

This is problematic if, for example, one keeps a test server config file under version control in a project's test resources directory while having the managed Wildfly instance outside of the code base, and one wants to continue to utilize system properties to set the server config. Setting the server config, regardless of location, via a system property is highly convenient and flexible.  This change maintains that ability by the introduction of an additional system property named jboss.server.config.file.name.readonly that sets the read-only server config allowing server config files outside of the server configuration directory to be specified via a system property.