### PR TITLE
[WFARQ-160] Propagate JUnit 'failed assumption' exception types from …

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/api/ServerSetupTask.java
+++ b/common/src/main/java/org/jboss/as/arquillian/api/ServerSetupTask.java
@@ -26,7 +26,39 @@ import org.jboss.as.arquillian.container.ManagementClient;
  */
 public interface ServerSetupTask {
 
+    /**
+     * Execute any necessary setup work that needs to happen before the first deployment
+     * to the given container.
+     * <p>
+     * <strong>Note on exception handling:</strong> If an implementation of this method
+     * throws {@code org.junit.AssumptionViolatedException}, the implementation can assume
+     * the following:
+     * <ol>
+     * <li>Any subsequent {@code ServerSetupTask}s {@link ServerSetup associated with test class}
+     * <strong>will not</strong> be executed.</li>
+     * <li>The deployment event that triggered the call to this method will be skipped.</li>
+     * <li>The {@link #tearDown(ManagementClient, String) tearDown} method of the instance
+     * that threw the exception <strong>will not</strong> be invoked. Therefore, implementations
+     * that throw {@code AssumptionViolatedException} should do so before altering any
+     * system state.</li>
+     * <li>The {@link #tearDown(ManagementClient, String) tearDown} method for any
+     * previously executed {@code ServerSetupTask}s {@link ServerSetup associated with test class}
+     * <strong>will</strong> be invoked.</li>
+     * </ol>
+     *
+     * @param managementClient management client to use to interact with the container
+     * @param containerId      id of the container to which the deployment will be deployed
+     * @throws Exception if a failure occurs
+     */
     void setup(ManagementClient managementClient, String containerId) throws Exception;
 
+    /**
+     * Execute any tear down work that needs to happen after the last deployment associated
+     * with the given container has been undeployed.
+     *
+     * @param managementClient management client to use to interact with the container
+     * @param containerId      id of the container to which the deployment will be deployed
+     * @throws Exception if a failure occurs
+     */
     void tearDown(ManagementClient managementClient, String containerId) throws Exception;
 }

--- a/container-bootable/pom.xml
+++ b/container-bootable/pom.xml
@@ -132,9 +132,18 @@
                         </goals>
                         <configuration>
                             <skip>false</skip>
+                            <!-- We want to run the not-enabled-by-default *TestSuite.java files,
+                                 so enumerate the expected test class patterns. -->
+                            <includes>
+                                <include>**/*Test.java</include>
+                                <include>**/*TestCase.java</include>
+                                <include>**/*TestSuite.java</include>
+                            </includes>
                             <excludedGroups>org.jboss.as.arquillian.container.managed.manual.ManualMode</excludedGroups>
                             <excludes>
                                 <exclude>**/ThreadContextClassloaderTest.java</exclude>
+                                <!-- These run as part of test suites -->
+                                <exclude>**/ServerSetup*TestCase.java</exclude>
                             </excludes>
                             <systemPropertyVariables>
                                 <install.dir>${jboss.home}</install.dir>

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/FailedDeployEjbBean.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/FailedDeployEjbBean.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.ejb.Remote;
+import jakarta.ejb.Stateless;
+
+/**
+ * An EJB that always fails in @PostConstruct. This bean is meant for use in that confirm
+ * that deployment by Arquillian of a managed deployment is disabled; this bean exists
+ * to trigger visible failure if the deployment happens.
+ */
+@Stateless
+@Remote(EjbBusiness.class)
+public class FailedDeployEjbBean implements EjbBusiness {
+
+    @PostConstruct
+    public void postConstruct() {
+        throw new UnsupportedOperationException("The deployment containing this bean should not have been deployed");
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAfterClassTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAfterClassTestCase.java
@@ -16,6 +16,8 @@
 
 package org.jboss.as.arquillian.container.managed;
 
+import static org.junit.Assert.assertEquals;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -35,10 +37,10 @@ public class ServerSetupAfterClassTestCase extends TestOperations {
     @ArquillianResource
     private ManagementClient client;
 
-    @Deployment
+    @Deployment(name = "ServerSetupAfterClassTestCase.jar")
     public static JavaArchive deployment() {
         // Create a dummy deployment so the client can be injected
-        return ShrinkWrap.create(JavaArchive.class).addManifest();
+        return ShrinkWrap.create(JavaArchive.class, "ServerSetupAfterClassTestCase.jar").addManifest();
     }
 
     @Test
@@ -46,6 +48,40 @@ public class ServerSetupAfterClassTestCase extends TestOperations {
         // All deployments from the ServerSetupDeploymentTestCase should have been undeployed and the
         // ServerSetupTask.tearDown() should have been invoked
         testSystemProperty(ServerSetupTestSuite.SYSTEM_PROPERTY_KEY);
+    }
+
+    /**
+     * Tests system state established by {@link ServerSetupAssumptionViolationTestCase}.
+     */
+    @Test
+    public void testAssumptionViolated() {
+        // BeforeSetup's tearDown should have executed
+        testInVMProperty(ServerSetupAssumptionViolationTestCase.BeforeSetup.PROPERTY, "tearDown");
+        // AssumptionViolatedSetup's tearDown should not have executed
+        // Note: A ServerSetupTask should not change state before throwing AVE, but we do here so we can verify setup ran
+        testInVMProperty(ServerSetupAssumptionViolationTestCase.AssumptionViolatedSetup.PROPERTY, "setup");
+        // AfterSetup should not have run at all, as AssumptionViolatedSetup threw an AVE
+        testInVMProperty(ServerSetupAssumptionViolationTestCase.AfterSetup.PROPERTY, "");
+    }
+
+    /**
+     * Tests system state established by {@link ServerSetupUnmanagedAssumptionViolationTestCase}.
+     */
+    @Test
+    public void testUnmanagedAssumptionViolated() {
+        // BeforeSetup's tearDown should have executed
+        testInVMProperty(ServerSetupUnmanagedAssumptionViolationTestCase.BeforeSetup.PROPERTY, "tearDown");
+        // AssumptionViolatedSetup's tearDown should not have executed
+        // Note: A ServerSetupTask should not change state before throwing AVE, but we do here so we can verify setup ran
+        testInVMProperty(ServerSetupUnmanagedAssumptionViolationTestCase.AssumptionViolatedSetup.PROPERTY, "setup");
+        // AfterSetup should not have run at all, as AssumptionViolatedSetup threw an AVE
+        testInVMProperty(ServerSetupUnmanagedAssumptionViolationTestCase.AfterSetup.PROPERTY, "");
+    }
+
+    private void testInVMProperty(String property, String expected) {
+        String value = System.getProperty(property, "");
+        System.clearProperty(property); // housekeeping
+        assertEquals("Unexpected value for " + property, expected, value);
     }
 
     @Override

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAssumptionTestBase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAssumptionTestBase.java
@@ -1,0 +1,79 @@
+package org.jboss.as.arquillian.container.managed;
+
+import static org.junit.Assert.fail;
+
+import java.util.function.Function;
+
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+
+abstract class ServerSetupAssumptionTestBase {
+
+    /**
+     * Creates a deployment that always fails to deploy. If the server setup task fails to disable
+     * further work on a test class that uses this, this will get deployed and fail.
+     *
+     * @param name the deployment archive file name
+     *
+     * @return a deployment that will fail to deploy
+     */
+    protected static JavaArchive createDeployment(String name) {
+        return ShrinkWrap.create(JavaArchive.class, name)
+                .addClasses(FailedDeployEjbBean.class, EjbBusiness.class);
+    }
+
+    @Test
+    public void test() {
+        fail("Test was not skipped");
+    }
+
+    static class AroundSetup implements ServerSetupTask {
+
+        private final String property;
+
+        AroundSetup(String property) {
+            this.property = property;
+        }
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) {
+            System.setProperty(property, "setup");
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) {
+            System.setProperty(property, "tearDown");
+        }
+    }
+
+    static class AssumptionViolatedSetup implements ServerSetupTask {
+
+        private final String property;
+        private final Function<String, RuntimeException> assumptionFailureProducer;
+
+        AssumptionViolatedSetup(String property) {
+            this(property, AssumptionViolatedException::new);
+        }
+
+        AssumptionViolatedSetup(String property, Function<String, RuntimeException> assumptionFailureProducer) {
+            this.property = property;
+            this.assumptionFailureProducer = assumptionFailureProducer;
+        }
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) {
+            System.setProperty(property, "setup");
+            throw assumptionFailureProducer.apply("always");
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) {
+            System.setProperty(property, "tearDown");
+            throw assumptionFailureProducer.apply("always");
+        }
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAssumptionViolationTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAssumptionViolationTestCase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AssumptionViolatedException;
+import org.junit.runner.RunWith;
+
+/**
+ * In conjunction with {@link ServerSetupAfterClassTestCase#testAssumptionViolated()}, tests
+ * what happens when a {@link ServerSetupTask} throws {@link AssumptionViolatedException}
+ * when it executes prior to Arquillian deploying a {@code @Deployment(managed=true)} deployment.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({
+        ServerSetupAssumptionViolationTestCase.BeforeSetup.class,
+        ServerSetupAssumptionViolationTestCase.AssumptionViolatedSetup.class,
+        ServerSetupAssumptionViolationTestCase.BeforeSetup.class
+})
+public class ServerSetupAssumptionViolationTestCase extends ServerSetupAssumptionTestBase {
+
+    private static final String DEPLOYMENT = "ServerSetupAssumptionViolationTestCase.jar";
+
+    /**
+     * A deployment that always fails to deploy. If the server setup task fails to disable
+     * further work on this test class, this will get deployed and fail.
+     *
+     * @return a deployment that will fail to deploy
+     */
+    @Deployment(name = DEPLOYMENT)
+    public static JavaArchive createDeployment() {
+        return createDeployment(DEPLOYMENT);
+    }
+
+    public static class BeforeSetup extends ServerSetupAssumptionTestBase.AroundSetup {
+
+        public static final String PROPERTY = BeforeSetup.class.getName();
+
+        public BeforeSetup() {
+            super(PROPERTY);
+        }
+    }
+
+    public static class AssumptionViolatedSetup extends ServerSetupAssumptionTestBase.AssumptionViolatedSetup {
+        public static final String PROPERTY = AssumptionViolatedSetup.class.getName();
+
+        public AssumptionViolatedSetup() {
+            super(PROPERTY);
+        }
+    }
+
+    public static class AfterSetup extends ServerSetupAssumptionTestBase.AroundSetup {
+
+        public static final String PROPERTY = AfterSetup.class.getName();
+
+        public AfterSetup() {
+            super(PROPERTY);
+        }
+    }
+}

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupTestSuite.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupTestSuite.java
@@ -27,6 +27,8 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
         ServerSetupDeploymentTestCase.class,
+        ServerSetupAssumptionViolationTestCase.class,
+        ServerSetupUnmanagedAssumptionViolationTestCase.class,
         ServerSetupAfterClassTestCase.class
 })
 public class ServerSetupTestSuite {

--- a/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupUnmanagedAssumptionViolationTestCase.java
+++ b/container-bootable/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupUnmanagedAssumptionViolationTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * In conjunction with {@link ServerSetupAfterClassTestCase#testAssumptionViolated()}, tests
+ * what happens when a {@link ServerSetupTask} throws {@link AssumptionViolatedException}
+ * when it executes prior to Arquillian deploying a {@code @Deployment(managed=false)} deployment.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({
+        ServerSetupUnmanagedAssumptionViolationTestCase.BeforeSetup.class,
+        ServerSetupUnmanagedAssumptionViolationTestCase.AssumptionViolatedSetup.class,
+        ServerSetupUnmanagedAssumptionViolationTestCase.BeforeSetup.class
+})
+public class ServerSetupUnmanagedAssumptionViolationTestCase extends ServerSetupAssumptionTestBase {
+
+    private static final String DEPLOYMENT = "ServerSetupUnmanagedAssumptionViolationTestCase.jar";
+
+    /**
+     * A deployment that always fails to deploy. If the server setup task fails to disable
+     * further work on this test class, this will get deployed and fail.
+     *
+     * @return a deployment that will fail to deploy
+     */
+    @Deployment(managed = false, name = DEPLOYMENT)
+    public static JavaArchive createDeployment() {
+        return createDeployment(DEPLOYMENT);
+    }
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Override
+    @Test
+    public void test() {
+        // Deploying should trigger the ServerSetupTasks and those should stop further processing
+        deployer.deploy(DEPLOYMENT);
+
+        super.test();
+    }
+
+    public static class BeforeSetup extends ServerSetupAssumptionTestBase.AroundSetup {
+
+        public static final String PROPERTY = BeforeSetup.class.getName();
+
+        public BeforeSetup() {
+            super(PROPERTY);
+        }
+    }
+
+    public static class AssumptionViolatedSetup extends ServerSetupAssumptionTestBase.AssumptionViolatedSetup {
+        public static final String PROPERTY = AssumptionViolatedSetup.class.getName();
+
+        public AssumptionViolatedSetup() {
+            super(PROPERTY);
+        }
+    }
+
+    public static class AfterSetup extends ServerSetupAssumptionTestBase.AroundSetup {
+
+        public static final String PROPERTY = AfterSetup.class.getName();
+
+        public AfterSetup() {
+            super(PROPERTY);
+        }
+    }
+}

--- a/container-managed/pom.xml
+++ b/container-managed/pom.xml
@@ -163,6 +163,13 @@
                         </goals>
                         <configuration>
                             <skip>false</skip>
+                            <!-- We want to run the not-enabled-by-default *TestSuite.java files,
+                                 so enumerate the expected test class patterns. -->
+                            <includes>
+                                <include>**/*Test.java</include>
+                                <include>**/*TestCase.java</include>
+                                <include>**/*TestSuite.java</include>
+                            </includes>
                             <excludedGroups>org.jboss.as.arquillian.container.managed.manual.ManualMode</excludedGroups>
                             <excludes>
                                 <exclude>**/AddAgentTestCase.java</exclude>
@@ -170,6 +177,8 @@
                                 <exclude>**/ManagedInContainerTestCase.java</exclude>
                                 <exclude>**/InContainerManualModeTestCase.java</exclude>
                                 <exclude>**/app/*.java</exclude>
+                                <!-- These run as part of test suites -->
+                                <exclude>**/ServerSetup*TestCase.java</exclude>
                             </excludes>
                         </configuration>
                     </execution>

--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/FailedDeployEjbBean.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/FailedDeployEjbBean.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.ejb.Remote;
+import jakarta.ejb.Stateless;
+
+/**
+ * An EJB that always fails in @PostConstruct. This bean is meant for use in that confirm
+ * that deployment by Arquillian of a managed deployment is disabled; this bean exists
+ * to trigger visible failure if the deployment happens.
+ */
+@Stateless
+@Remote(EjbBusiness.class)
+public class FailedDeployEjbBean implements EjbBusiness {
+
+    @PostConstruct
+    public void postConstruct() {
+        throw new UnsupportedOperationException("The deployment containing this bean should not have been deployed");
+    }
+}

--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAfterClassTestCase.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAfterClassTestCase.java
@@ -16,6 +16,8 @@
 
 package org.jboss.as.arquillian.container.managed;
 
+import static org.junit.Assert.assertEquals;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -35,10 +37,10 @@ public class ServerSetupAfterClassTestCase extends TestOperations {
     @ArquillianResource
     private ManagementClient client;
 
-    @Deployment
+    @Deployment(name = "ServerSetupAfterClassTestCase.jar")
     public static JavaArchive deployment() {
         // Create a dummy deployment so the client can be injected
-        return ShrinkWrap.create(JavaArchive.class).addManifest();
+        return ShrinkWrap.create(JavaArchive.class, "ServerSetupAfterClassTestCase.jar").addManifest();
     }
 
     @Test
@@ -46,6 +48,40 @@ public class ServerSetupAfterClassTestCase extends TestOperations {
         // All deployments from the ServerSetupDeploymentTestCase should have been undeployed and the
         // ServerSetupTask.tearDown() should have been invoked
         testSystemProperty(ServerSetupTestSuite.SYSTEM_PROPERTY_KEY);
+    }
+
+    /**
+     * Tests system state established by {@link ServerSetupAssumptionViolationTestCase}.
+     */
+    @Test
+    public void testAssumptionViolated() {
+        // BeforeSetup's tearDown should have executed
+        testInVMProperty(ServerSetupAssumptionViolationTestCase.BeforeSetup.PROPERTY, "tearDown");
+        // AssumptionViolatedSetup's tearDown should not have executed
+        // Note: A ServerSetupTask should not change state before throwing AVE, but we do here so we can verify setup ran
+        testInVMProperty(ServerSetupAssumptionViolationTestCase.AssumptionViolatedSetup.PROPERTY, "setup");
+        // AfterSetup should not have run at all, as AssumptionViolatedSetup threw an AVE
+        testInVMProperty(ServerSetupAssumptionViolationTestCase.AfterSetup.PROPERTY, "");
+    }
+
+    /**
+     * Tests system state established by {@link ServerSetupUnmanagedAssumptionViolationTestCase}.
+     */
+    @Test
+    public void testUnmanagedAssumptionViolated() {
+        // BeforeSetup's tearDown should have executed
+        testInVMProperty(ServerSetupUnmanagedAssumptionViolationTestCase.BeforeSetup.PROPERTY, "tearDown");
+        // AssumptionViolatedSetup's tearDown should not have executed
+        // Note: A ServerSetupTask should not change state before throwing AVE, but we do here so we can verify setup ran
+        testInVMProperty(ServerSetupUnmanagedAssumptionViolationTestCase.AssumptionViolatedSetup.PROPERTY, "setup");
+        // AfterSetup should not have run at all, as AssumptionViolatedSetup threw an AVE
+        testInVMProperty(ServerSetupUnmanagedAssumptionViolationTestCase.AfterSetup.PROPERTY, "");
+    }
+
+    private void testInVMProperty(String property, String expected) {
+        String value = System.getProperty(property, "");
+        System.clearProperty(property); // housekeeping
+        assertEquals("Unexpected value for " + property, expected, value);
     }
 
     @Override

--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAssumptionTestBase.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAssumptionTestBase.java
@@ -1,0 +1,79 @@
+package org.jboss.as.arquillian.container.managed;
+
+import static org.junit.Assert.fail;
+
+import java.util.function.Function;
+
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+
+abstract class ServerSetupAssumptionTestBase {
+
+    /**
+     * Creates a deployment that always fails to deploy. If the server setup task fails to disable
+     * further work on a test class that uses this, this will get deployed and fail.
+     *
+     * @param name the deployment archive file name
+     *
+     * @return a deployment that will fail to deploy
+     */
+    protected static JavaArchive createDeployment(String name) {
+        return ShrinkWrap.create(JavaArchive.class, name)
+                .addClasses(FailedDeployEjbBean.class, EjbBusiness.class);
+    }
+
+    @Test
+    public void test() {
+        fail("Test was not skipped");
+    }
+
+    static class AroundSetup implements ServerSetupTask {
+
+        private final String property;
+
+        AroundSetup(String property) {
+            this.property = property;
+        }
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) {
+            System.setProperty(property, "setup");
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) {
+            System.setProperty(property, "tearDown");
+        }
+    }
+
+    static class AssumptionViolatedSetup implements ServerSetupTask {
+
+        private final String property;
+        private final Function<String, RuntimeException> assumptionFailureProducer;
+
+        AssumptionViolatedSetup(String property) {
+            this(property, AssumptionViolatedException::new);
+        }
+
+        AssumptionViolatedSetup(String property, Function<String, RuntimeException> assumptionFailureProducer) {
+            this.property = property;
+            this.assumptionFailureProducer = assumptionFailureProducer;
+        }
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) {
+            System.setProperty(property, "setup");
+            throw assumptionFailureProducer.apply("always");
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) {
+            System.setProperty(property, "tearDown");
+            throw assumptionFailureProducer.apply("always");
+        }
+    }
+}

--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAssumptionViolationTestCase.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAssumptionViolationTestCase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AssumptionViolatedException;
+import org.junit.runner.RunWith;
+
+/**
+ * In conjunction with {@link ServerSetupAfterClassTestCase#testAssumptionViolated()}, tests
+ * what happens when a {@link ServerSetupTask} throws {@link AssumptionViolatedException}
+ * when it executes prior to Arquillian deploying a {@code @Deployment(managed=true)} deployment.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({
+        ServerSetupAssumptionViolationTestCase.BeforeSetup.class,
+        ServerSetupAssumptionViolationTestCase.AssumptionViolatedSetup.class,
+        ServerSetupAssumptionViolationTestCase.BeforeSetup.class
+})
+public class ServerSetupAssumptionViolationTestCase extends ServerSetupAssumptionTestBase {
+
+    private static final String DEPLOYMENT = "ServerSetupAssumptionViolationTestCase.jar";
+
+    /**
+     * A deployment that always fails to deploy. If the server setup task fails to disable
+     * further work on this test class, this will get deployed and fail.
+     *
+     * @return a deployment that will fail to deploy
+     */
+    @Deployment(name = DEPLOYMENT)
+    public static JavaArchive createDeployment() {
+        return createDeployment(DEPLOYMENT);
+    }
+
+    public static class BeforeSetup extends ServerSetupAssumptionTestBase.AroundSetup {
+
+        public static final String PROPERTY = BeforeSetup.class.getName();
+
+        public BeforeSetup() {
+            super(PROPERTY);
+        }
+    }
+
+    public static class AssumptionViolatedSetup extends ServerSetupAssumptionTestBase.AssumptionViolatedSetup {
+        public static final String PROPERTY = AssumptionViolatedSetup.class.getName();
+
+        public AssumptionViolatedSetup() {
+            super(PROPERTY);
+        }
+    }
+
+    public static class AfterSetup extends ServerSetupAssumptionTestBase.AroundSetup {
+
+        public static final String PROPERTY = AfterSetup.class.getName();
+
+        public AfterSetup() {
+            super(PROPERTY);
+        }
+    }
+}

--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupTestSuite.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupTestSuite.java
@@ -27,6 +27,8 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
         ServerSetupDeploymentTestCase.class,
+        ServerSetupAssumptionViolationTestCase.class,
+        ServerSetupUnmanagedAssumptionViolationTestCase.class,
         ServerSetupAfterClassTestCase.class
 })
 public class ServerSetupTestSuite {

--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupUnmanagedAssumptionViolationTestCase.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupUnmanagedAssumptionViolationTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * In conjunction with {@link ServerSetupAfterClassTestCase#testAssumptionViolated()}, tests
+ * what happens when a {@link ServerSetupTask} throws {@link AssumptionViolatedException}
+ * when it executes prior to Arquillian deploying a {@code @Deployment(managed=false)} deployment.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({
+        ServerSetupUnmanagedAssumptionViolationTestCase.BeforeSetup.class,
+        ServerSetupUnmanagedAssumptionViolationTestCase.AssumptionViolatedSetup.class,
+        ServerSetupUnmanagedAssumptionViolationTestCase.BeforeSetup.class
+})
+public class ServerSetupUnmanagedAssumptionViolationTestCase extends ServerSetupAssumptionTestBase {
+
+    private static final String DEPLOYMENT = "ServerSetupUnmanagedAssumptionViolationTestCase.jar";
+
+    /**
+     * A deployment that always fails to deploy. If the server setup task fails to disable
+     * further work on this test class, this will get deployed and fail.
+     *
+     * @return a deployment that will fail to deploy
+     */
+    @Deployment(managed = false, name = DEPLOYMENT)
+    public static JavaArchive createDeployment() {
+        return createDeployment(DEPLOYMENT);
+    }
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Override
+    @Test
+    public void test() {
+        // Deploying should trigger the ServerSetupTasks and those should stop further processing
+        deployer.deploy(DEPLOYMENT);
+
+        super.test();
+    }
+
+    public static class BeforeSetup extends ServerSetupAssumptionTestBase.AroundSetup {
+
+        public static final String PROPERTY = BeforeSetup.class.getName();
+
+        public BeforeSetup() {
+            super(PROPERTY);
+        }
+    }
+
+    public static class AssumptionViolatedSetup extends ServerSetupAssumptionTestBase.AssumptionViolatedSetup {
+        public static final String PROPERTY = AssumptionViolatedSetup.class.getName();
+
+        public AssumptionViolatedSetup() {
+            super(PROPERTY);
+        }
+    }
+
+    public static class AfterSetup extends ServerSetupAssumptionTestBase.AroundSetup {
+
+        public static final String PROPERTY = AfterSetup.class.getName();
+
+        public AfterSetup() {
+            super(PROPERTY);
+        }
+    }
+}


### PR DESCRIPTION
…ServerSetupObserver

https://issues.redhat.com/browse/WFARQ-160

Note there are a couple of TODO comments in ServerSetupObserver, which relate to the JUnit 5 'org.opentest4j.TestAbortedException' class. That is its analogue to the JUnit 4 'org.junit.AssumptionViolatedException' that I deal with here. I left handling that as a TODO because JUnit 5 still handles 'AssumptionViolatedException' if test code throws it. So, ServerSetupTask implementors being able to throw TestAbortedException is more of a nice-to-have.

That said, the code to handle TestAbortedException is probably all there; just a couple lines need uncommenting. The test infrastructure to test it is also mostly there. I just don't have time now to actually set up tests that use @ExtendWith(ArquillianExtension.class) etc.