### PR TITLE
[WFARQ-162] Ignore the SNAPSHOT qualifier when comparing versions

### DIFF
--- a/junit-api/src/main/java/org/wildfly/arquillian/junit/condition/RequiresModuleExecutionCondition.java
+++ b/junit-api/src/main/java/org/wildfly/arquillian/junit/condition/RequiresModuleExecutionCondition.java
@@ -185,7 +185,7 @@ public class RequiresModuleExecutionCondition implements ExecutionCondition {
         if (foundVersion == null) {
             return false;
         }
-        return VersionComparator.compareVersion(foundVersion, minVersion) >= 0;
+        return foundVersion.equals(minVersion) || VersionComparator.compareVersion(true, foundVersion, minVersion) >= 0;
     }
 
     private static String formatReason(final RequiresModule requiresModule, final String fmt, final Object... args) {

--- a/junit-api/src/test/java/org/wildfly/arquillian/junit/requires/module/RequireSnapshot.java
+++ b/junit-api/src/test/java/org/wildfly/arquillian/junit/requires/module/RequireSnapshot.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.junit.requires.module;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.arquillian.junit.annotations.RequiresModule;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("NewClassNamingConvention")
+@RequiresModule("org.wildfly.arquillian.junit.test.snapshot")
+public class RequireSnapshot {
+
+    @Test
+    @RequiresModule(value = "org.wildfly.arquillian.junit.test.snapshot", minVersion = "1.0.0.Beta2")
+    public void passingVersion() {
+    }
+
+    @Test
+    @RequiresModule(value = "org.wildfly.arquillian.junit.test.snapshot", minVersion = "1.0.0.Beta3")
+    public void skippedVersion() {
+    }
+}

--- a/junit-api/src/test/resources/fake-modules/modules/org/wildfly/arquillian/junit/test/snapshot/main/module.xml
+++ b/junit-api/src/test/resources/fake-modules/modules/org/wildfly/arquillian/junit/test/snapshot/main/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="org.wildfly.arquillian.junit.test.snapshot" xmlns="urn:jboss:module:1.9">
+
+    <resources>
+        <resource-root path="test-1.0.0.Beta2-SNAPSHOT.jar" />
+    </resources>
+
+    <dependencies>
+        <module name="java.logging" />
+    </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.wildfly.tools</groupId>
         <artifactId>wildfly-parent</artifactId>
-        <version>1.0.3.Final</version>
+        <version>1.0.4.Final</version>
     </parent>
 
     <artifactId>wildfly-arquillian-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <version.org.wildfly.common.wildfly-common>1.7.0.Final</version.org.wildfly.common.wildfly-common>
         <version.org.wildfly.plugins.wildfly-jar-maven-plugin>10.0.0.Final</version.org.wildfly.plugins.wildfly-jar-maven-plugin>
         <version.org.wildfly.plugins.wildfly-maven-plugin>4.2.2.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
-        <version.org.wildfly.plugins.wildfly-plugin-tools>1.0.0.Beta3</version.org.wildfly.plugins.wildfly-plugin-tools>
+        <version.org.wildfly.plugins.wildfly-plugin-tools>1.0.0.Beta4</version.org.wildfly.plugins.wildfly-plugin-tools>
 
         <!-- keep this in sync with version that is used in arquillian -->
         <version.org.jboss.shrinkwrap.descriptors>2.0.0</version.org.jboss.shrinkwrap.descriptors>


### PR DESCRIPTION
Note this also requires an upgrade to the wildfly-plugin-tools.

- https://issues.redhat.com/browse/WFARQ-162
- https://issues.redhat.com/browse/WFARQ-163