### PR TITLE
Upgrade the wildfly-maven-plugin and the wildfly-jar-maven-plugin to …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <version.org.wildfly.core>23.0.3.Final</version.org.wildfly.core>
-        <version.org.wildfly.full>30.0.0.Final</version.org.wildfly.full>
+        <version.org.wildfly.full>31.0.1.Final</version.org.wildfly.full>
         <version.io.smallrye.jandex>3.1.6</version.io.smallrye.jandex>
         <version.junit>4.13.2</version.junit>
         <version.org.junit>5.10.2</version.org.junit>
@@ -50,8 +50,8 @@
         <!-- Required by Elytron dependencies -->
         <version.org.slf4j>1.7.36</version.org.slf4j>
         <version.org.wildfly.common.wildfly-common>1.7.0.Final</version.org.wildfly.common.wildfly-common>
-        <version.org.wildfly.plugins.wildfly-jar-maven-plugin>10.0.0.Final</version.org.wildfly.plugins.wildfly-jar-maven-plugin>
-        <version.org.wildfly.plugins.wildfly-maven-plugin>4.2.2.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
+        <version.org.wildfly.plugins.wildfly-jar-maven-plugin>11.0.0.Beta2</version.org.wildfly.plugins.wildfly-jar-maven-plugin>
+        <version.org.wildfly.plugins.wildfly-maven-plugin>5.0.0.Beta4</version.org.wildfly.plugins.wildfly-maven-plugin>
         <version.org.wildfly.plugins.wildfly-plugin-tools>1.0.0.Beta4</version.org.wildfly.plugins.wildfly-plugin-tools>
 
         <!-- keep this in sync with version that is used in arquillian -->
@@ -89,7 +89,6 @@
         <test.debug.port>5005</test.debug.port>
 
         <!-- Release properties -->
-        <version.release.plugin>3.0.0-M6</version.release.plugin>
         <autoVersionSubmodules>true</autoVersionSubmodules>
         <pushChanges>false</pushChanges>
 


### PR DESCRIPTION
…work with newer versions of WildFly. Remove the release plugin version override. Upgrade WildFly test to 31.0.1.Final.