### PR TITLE
[WFARQ-160] Enable assumptions for JUnit 5 and TestNG. Add tests for …

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
@@ -216,9 +216,11 @@ public class ServerSetupObserver {
         private static final Class<?> ASSUMPTION_VIOLATED_EXCEPTION = loadAssumptionFailureClass(
                 "org.junit.AssumptionViolatedException");
 
-        // TODO Support this after adding tests of org.opentest4j.TestAbortedException handling
-        // private static final Class<?> TEST_ABORTED_EXCEPTION = loadAssumptionFailureClass(
-        // "org.opentest4j.TestAbortedException");
+        private static final Class<?> TEST_ABORTED_EXCEPTION = loadAssumptionFailureClass(
+                "org.opentest4j.TestAbortedException");
+
+        private static final Class<?> TESTNG_SKIPPED_EXCEPTION = loadAssumptionFailureClass(
+                "org.testng.SkipException");
 
         @SuppressWarnings("SameParameterValue")
         private static Class<?> loadAssumptionFailureClass(String classname) {
@@ -295,8 +297,8 @@ public class ServerSetupObserver {
 
         private void rethrowFailedAssumptions(final Throwable t, final String containerName) throws FailedAssumptionException {
             rethrowFailedAssumption(t, ASSUMPTION_VIOLATED_EXCEPTION);
-            // TODO Support this after adding tests of org.opentest4j.TestAbortedException handling
-            // rethrowFailedAssumption(t, TEST_ABORTED_EXCEPTION);
+            rethrowFailedAssumption(t, TEST_ABORTED_EXCEPTION);
+            rethrowFailedAssumption(t, TESTNG_SKIPPED_EXCEPTION);
         }
 
         @SuppressWarnings("SameParameterValue")

--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAssumptionViolationTestCase.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupAssumptionViolationTestCase.java
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 @ServerSetup({
         ServerSetupAssumptionViolationTestCase.BeforeSetup.class,
         ServerSetupAssumptionViolationTestCase.AssumptionViolatedSetup.class,
-        ServerSetupAssumptionViolationTestCase.BeforeSetup.class
+        ServerSetupAssumptionViolationTestCase.AfterSetup.class
 })
 public class ServerSetupAssumptionViolationTestCase extends ServerSetupAssumptionTestBase {
 

--- a/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupUnmanagedAssumptionViolationTestCase.java
+++ b/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ServerSetupUnmanagedAssumptionViolationTestCase.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 @ServerSetup({
         ServerSetupUnmanagedAssumptionViolationTestCase.BeforeSetup.class,
         ServerSetupUnmanagedAssumptionViolationTestCase.AssumptionViolatedSetup.class,
-        ServerSetupUnmanagedAssumptionViolationTestCase.BeforeSetup.class
+        ServerSetupUnmanagedAssumptionViolationTestCase.AfterSetup.class
 })
 public class ServerSetupUnmanagedAssumptionViolationTestCase extends ServerSetupAssumptionTestBase {
 

--- a/integration-tests/junit5-tests/pom.xml
+++ b/integration-tests/junit5-tests/pom.xml
@@ -64,6 +64,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-testkit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
             <scope>test</scope>
@@ -94,7 +99,7 @@
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <groups>!OverrideWebUri</groups>
+                            <excludedGroups>OverrideWebUri,engine-test-kit</excludedGroups>
                         </configuration>
                     </execution>
                     <execution>
@@ -107,6 +112,15 @@
                             <systemPropertyVariables>
                                 <arquillian.xml>override-web-uri-arquillian.xml</arquillian.xml>
                             </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>engine-test-kit</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <groups>engine-test-kit</groups>
                         </configuration>
                     </execution>
                 </executions>

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/AbstractAssumptionTestCase.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/AbstractAssumptionTestCase.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.server.setup;
+
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ServerSetup(AbstractAssumptionTestCase.AssumingServerSetupTask.class)
+abstract class AbstractAssumptionTestCase {
+
+    public static class AssumingServerSetupTask implements ServerSetupTask {
+
+        @Override
+        public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+            Assumptions.abort("Abort on purpose");
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+
+        }
+    }
+
+    @Test
+    public void failIfExecuted() {
+        Assertions.fail("This should have been skipped and not executed");
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/AssumptionServerSetup.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/AssumptionServerSetup.java
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.server.setup;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.wildfly.arquillian.integration.test.junit5.GreeterServlet;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("NewClassNamingConvention")
+@ExtendWith(ArquillianExtension.class)
+@RunAsClient
+public class AssumptionServerSetup extends AbstractAssumptionTestCase {
+
+    @Deployment
+    public static WebArchive create() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClass(GreeterServlet.class);
+    }
+
+    @BeforeAll
+    public static void failBeforeAll(final TestInfo testInfo) {
+        Assertions.fail(() -> String.format("%s.%s should not have executed.", testInfo.getTestClass()
+                .orElseThrow().getSimpleName(),
+                testInfo.getTestMethod().orElseThrow().getName()));
+    }
+
+    @BeforeEach
+    public void failBefore(final TestInfo testInfo) {
+        Assertions.fail(() -> String.format("%s.%s should not have executed.", testInfo.getTestClass()
+                .orElseThrow().getSimpleName(),
+                testInfo.getTestMethod().orElseThrow().getName()));
+    }
+
+    @AfterAll
+    public static void failAfterAll(final TestInfo testInfo) {
+        Assertions.fail(() -> String.format("%s.%s should not have executed.", testInfo.getTestClass()
+                .orElseThrow().getSimpleName(),
+                testInfo.getTestMethod().orElseThrow().getName()));
+    }
+
+    @AfterEach
+    public void failAfter(final TestInfo testInfo) {
+        Assertions.fail(() -> String.format("%s.%s should not have executed.", testInfo.getTestClass()
+                .orElseThrow().getSimpleName(),
+                testInfo.getTestMethod().orElseThrow().getName()));
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/AssumptionTestCase.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/AssumptionTestCase.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.server.setup;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@Tag("engine-test-kit")
+public class AssumptionTestCase {
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            AssumptionServerSetup.class,
+            InContainerAssumptionServerSetup.class,
+            UnmanagedAssumptionServerSetup.class
+    })
+    public void serverSetup(final Class<?> testClass) {
+        final var events = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectMethod(testClass, "failIfExecuted"))
+                // .enableImplicitConfigurationParameters(true)
+                .execute()
+                .allEvents();
+
+        // Should have a single aborted event and no failures.
+        events.assertStatistics((stats) -> stats.aborted(1L));
+        events.assertStatistics((stats) -> stats.failed(0L));
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/InContainerAssumptionServerSetup.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/InContainerAssumptionServerSetup.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.server.setup;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.wildfly.arquillian.integration.test.junit5.GreeterServlet;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("NewClassNamingConvention")
+@ExtendWith(ArquillianExtension.class)
+public class InContainerAssumptionServerSetup extends AbstractAssumptionTestCase {
+
+    @Deployment
+    public static WebArchive create() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(GreeterServlet.class, ServerSetupTask.class);
+    }
+
+    @BeforeAll
+    public static void failBeforeAll(final TestInfo testInfo) {
+        Assertions.fail(() -> String.format("%s.%s should not have executed.", testInfo.getTestClass()
+                .orElseThrow().getSimpleName(),
+                testInfo.getTestMethod().orElseThrow().getName()));
+    }
+
+    @BeforeEach
+    public void failBefore(final TestInfo testInfo) {
+        Assertions.fail(() -> String.format("%s.%s should not have executed.", testInfo.getTestClass()
+                .orElseThrow().getSimpleName(),
+                testInfo.getTestMethod().orElseThrow().getName()));
+    }
+
+    @AfterAll
+    public static void failAfterAll(final TestInfo testInfo) {
+        Assertions.fail(() -> String.format("%s.%s should not have executed.", testInfo.getTestClass()
+                .orElseThrow().getSimpleName(),
+                testInfo.getTestMethod().orElseThrow().getName()));
+    }
+
+    @AfterEach
+    public void failAfter(final TestInfo testInfo) {
+        Assertions.fail(() -> String.format("%s.%s should not have executed.", testInfo.getTestClass()
+                .orElseThrow().getSimpleName(),
+                testInfo.getTestMethod().orElseThrow().getName()));
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/UnmanagedAssumptionServerSetup.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/UnmanagedAssumptionServerSetup.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.server.setup;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.wildfly.arquillian.integration.test.junit5.GreeterServlet;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("NewClassNamingConvention")
+@ExtendWith(ArquillianExtension.class)
+@RunAsClient
+public class UnmanagedAssumptionServerSetup extends AbstractAssumptionTestCase {
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Deployment(managed = false, name = "unmanaged")
+    public static WebArchive create() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClass(GreeterServlet.class);
+    }
+
+    @Override
+    @Test
+    public void failIfExecuted() {
+        // Until ARQ-2231 this must happen in the test context
+        deployer.deploy("unmanaged");
+        super.failIfExecuted();
+    }
+}

--- a/testng-integration/src/test/java/org/jboss/as/arquillian/testng/AbstractAssumptionTestCase.java
+++ b/testng-integration/src/test/java/org/jboss/as/arquillian/testng/AbstractAssumptionTestCase.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.testng;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ServerSetup(AbstractAssumptionTestCase.AssumingServerSetupTask.class)
+public class AbstractAssumptionTestCase extends Arquillian {
+
+    public static class AssumingServerSetupTask implements ServerSetupTask {
+
+        @Override
+        public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+            throw new SkipException("Skipping test from server setup");
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+
+        }
+    }
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "testng.war")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void failIfExecuted() {
+        Assert.fail("This should have been skipped and not executed");
+    }
+}

--- a/testng-integration/src/test/java/org/jboss/as/arquillian/testng/AssumptionTestCase.java
+++ b/testng-integration/src/test/java/org/jboss/as/arquillian/testng/AssumptionTestCase.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.testng;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunAsClient
+public class AssumptionTestCase extends AbstractAssumptionTestCase {
+}

--- a/testng-integration/src/test/java/org/jboss/as/arquillian/testng/InContainerAssumptionTestCase.java
+++ b/testng-integration/src/test/java/org/jboss/as/arquillian/testng/InContainerAssumptionTestCase.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.testng;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class InContainerAssumptionTestCase extends AbstractAssumptionTestCase {
+}


### PR DESCRIPTION
…ensuring an assumption failure or SkipException skips tests if thrown in a ServerSetupTask.

https://issues.redhat.com/browse/WFARQ-160

Follows up on #435 