### PR TITLE
Upgrade WildFly Plugin Tools and add new utilities and behavior  

### DIFF
--- a/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ArchiveDeployer.java
+++ b/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ArchiveDeployer.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Future;
 
@@ -39,7 +40,6 @@ import org.jboss.as.controller.client.helpers.domain.UndeployDeploymentPlanBuild
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
-import org.wildfly.common.Assert;
 import org.wildfly.plugin.tools.Deployment;
 import org.wildfly.plugin.tools.DeploymentManager;
 import org.wildfly.plugin.tools.DeploymentResult;
@@ -56,7 +56,7 @@ import org.wildfly.plugin.tools.UndeployDescription;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  * @since 17-Nov-2010
  */
-@SuppressWarnings({ "WeakerAccess", "TypeMayBeWeakened", "DeprecatedIsStillUsed", "deprecation", "unused" })
+@SuppressWarnings({ "WeakerAccess", "TypeMayBeWeakened", "DeprecatedIsStillUsed", "unused" })
 public class ArchiveDeployer {
 
     private static final Logger log = Logger.getLogger(ArchiveDeployer.class);
@@ -77,8 +77,7 @@ public class ArchiveDeployer {
      */
     @Deprecated
     public ArchiveDeployer(DomainDeploymentManager deploymentManager) {
-        Assert.checkNotNullParam("deploymentManager", deploymentManager);
-        this.deploymentManagerDeprecated = deploymentManager;
+        this.deploymentManagerDeprecated = Objects.requireNonNull(deploymentManager, "The deploymentManager cannot be null");
         this.deploymentManager = null;
     }
 
@@ -88,7 +87,7 @@ public class ArchiveDeployer {
      * @param client the client used to communicate with the server
      */
     public ArchiveDeployer(final ManagementClient client) {
-        Assert.checkNotNullParam("client", client);
+        Objects.requireNonNull(client, "The client cannot be null");
         deploymentManagerDeprecated = null;
         this.deploymentManager = DeploymentManager.Factory.create(client.getControllerClient());
     }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -66,6 +66,10 @@
             <artifactId>remoting-jmx</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-testing-tools</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller-client</artifactId>
         </dependency>
@@ -80,10 +84,6 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap.descriptors</groupId>
             <artifactId>shrinkwrap-descriptors-impl-base</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.common</groupId>
-            <artifactId>wildfly-common</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/common/src/main/java/org/jboss/as/arquillian/api/ServerSetupTask.java
+++ b/common/src/main/java/org/jboss/as/arquillian/api/ServerSetupTask.java
@@ -39,20 +39,25 @@ public interface ServerSetupTask {
      * to the given container.
      * <p>
      * <strong>Note on exception handling:</strong> If an implementation of this method
-     * throws {@code org.junit.AssumptionViolatedException}, the implementation can assume
-     * the following:
+     * throws any exception, the implementation can assume the following:
      * <ol>
      * <li>Any subsequent {@code ServerSetupTask}s {@link ServerSetup associated with test class}
      * <strong>will not</strong> be executed.</li>
      * <li>The deployment event that triggered the call to this method will be skipped.</li>
      * <li>The {@link #tearDown(ManagementClient, String) tearDown} method of the instance
      * that threw the exception <strong>will not</strong> be invoked. Therefore, implementations
-     * that throw {@code AssumptionViolatedException} should do so before altering any
+     * that throw {@code AssumptionViolatedException}, or any other exception, should do so before altering any
      * system state.</li>
      * <li>The {@link #tearDown(ManagementClient, String) tearDown} method for any
      * previously executed {@code ServerSetupTask}s {@link ServerSetup associated with test class}
      * <strong>will</strong> be invoked.</li>
      * </ol>
+     * <p>
+     * If any other exception is thrown, the {@link #tearDown(ManagementClient, String)} will be executed, including
+     * this implementations {@code tearDown()}, re-throwing the original exception. The original exception will have
+     * any other exceptions thrown in the {@code tearDown()} methods add as
+     * {@linkplain Throwable#addSuppressed(Throwable) suppressed} messages.
+     * </p>
      *
      * @param managementClient management client to use to interact with the container
      * @param containerId      id of the container to which the deployment will be deployed

--- a/common/src/main/java/org/jboss/as/arquillian/container/ArquillianServerManager.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ArquillianServerManager.java
@@ -1,0 +1,129 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.plugin.tools.ContainerDescription;
+import org.wildfly.plugin.tools.DeploymentManager;
+import org.wildfly.plugin.tools.server.ServerManager;
+
+/**
+ * A delegating implementation of a {@link ServerManager} which does not allow {@link #shutdown()} attempts. If either
+ * shutdown method is invoked, an {@link UnsupportedOperationException} will be thrown.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class ArquillianServerManager implements ServerManager {
+
+    private final ServerManager delegate;
+
+    ArquillianServerManager(ServerManager delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ModelControllerClient client() {
+        return delegate.client();
+    }
+
+    @Override
+    public String serverState() {
+        return delegate.serverState();
+    }
+
+    @Override
+    public String launchType() {
+        return delegate.launchType();
+    }
+
+    @Override
+    public String takeSnapshot() throws IOException {
+        return delegate.takeSnapshot();
+    }
+
+    @Override
+    public ContainerDescription containerDescription() throws IOException {
+        return delegate.containerDescription();
+    }
+
+    @Override
+    public DeploymentManager deploymentManager() {
+        return delegate.deploymentManager();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return delegate.isRunning();
+    }
+
+    @Override
+    public boolean waitFor(final long startupTimeout) throws InterruptedException {
+        return delegate.waitFor(startupTimeout);
+    }
+
+    @Override
+    public boolean waitFor(final long startupTimeout, final TimeUnit unit) throws InterruptedException {
+        return delegate.waitFor(startupTimeout, unit);
+    }
+
+    /**
+     * Throws an {@link UnsupportedOperationException} as the server is managed by Arquillian
+     *
+     * @throws UnsupportedOperationException as the server is managed by Arquillian
+     */
+    @Override
+    public void shutdown() throws UnsupportedOperationException {
+        throw new UnsupportedOperationException("Cannot shutdown a server managed by Arquillian");
+    }
+
+    /**
+     * Throws an {@link UnsupportedOperationException} as the server is managed by Arquillian
+     *
+     * @throws UnsupportedOperationException s the server is managed by Arquillian
+     */
+    @Override
+    public void shutdown(final long timeout) throws UnsupportedOperationException {
+        throw new UnsupportedOperationException("Cannot shutdown a server managed by Arquillian");
+    }
+
+    @Override
+    public void executeReload() throws IOException {
+        delegate.executeReload();
+    }
+
+    @Override
+    public void executeReload(final ModelNode reloadOp) throws IOException {
+        delegate.executeReload(reloadOp);
+    }
+
+    @Override
+    public void reloadIfRequired() throws IOException {
+        delegate.reloadIfRequired();
+    }
+
+    @Override
+    public void reloadIfRequired(final long timeout, final TimeUnit unit) throws IOException {
+        delegate.reloadIfRequired(timeout, unit);
+    }
+}

--- a/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerArchiveAppender.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerArchiveAppender.java
@@ -22,6 +22,7 @@ package org.jboss.as.arquillian.container;
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.setup.ConfigureLoggingSetupTask;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -42,6 +43,8 @@ public class CommonContainerArchiveAppender implements AuxiliaryArchiveAppender 
                 // shouldn't really be used for in-container tests.
                 .addClasses(ServerSetupTask.class, ServerSetup.class)
                 .addClasses(ManagementClient.class)
+                // Add the setup task implementations
+                .addPackage(ConfigureLoggingSetupTask.class.getPackage())
                 // Adds wildfly-plugin-tools, this exception itself is explicitly needed
                 .addPackages(true, OperationExecutionException.class.getPackage())
                 .setManifest(new StringAsset("Manifest-Version: 1.0\n"

--- a/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerArchiveAppender.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerArchiveAppender.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.wildfly.plugin.tools.OperationExecutionException;
+
+/**
+ * Creates a library to add to deployments for common container based dependencies for in-container tests.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class CommonContainerArchiveAppender implements AuxiliaryArchiveAppender {
+
+    @Override
+    public Archive<?> createAuxiliaryArchive() {
+        return ShrinkWrap.create(JavaArchive.class, "wildfly-common-testencricher.jar")
+                // These two types are added to avoid exceptions with class loading for in-container tests. These
+                // shouldn't really be used for in-container tests.
+                .addClasses(ServerSetupTask.class, ServerSetup.class)
+                .addClasses(ManagementClient.class)
+                // Adds wildfly-plugin-tools, this exception itself is explicitly needed
+                .addPackages(true, OperationExecutionException.class.getPackage())
+                .setManifest(new StringAsset("Manifest-Version: 1.0\n"
+                        + "Dependencies: org.jboss.as.controller-client,org.jboss.dmr\n"));
+    }
+}

--- a/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerExtension.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerExtension.java
@@ -39,6 +39,10 @@ public class CommonContainerExtension implements LoadableExtension {
         builder.service(DeploymentExceptionTransformer.class, ExceptionTransformer.class);
         builder.service(ResourceProvider.class, ArchiveDeployerProvider.class);
         builder.service(ResourceProvider.class, ManagementClientProvider.class);
+        // Set up the providers for client injection of a ServerManager. We will not support injection for in-container
+        // tests. The main reason for this is we likely shouldn't be managing a servers lifecycle from a deployment. In
+        // some cases it may not even work.
+        builder.service(ResourceProvider.class, ServerManagerProvider.class);
         builder.service(TestEnricher.class, ContainerResourceTestEnricher.class);
         builder.service(AuxiliaryArchiveAppender.class, CommonContainerArchiveAppender.class);
 

--- a/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerExtension.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerExtension.java
@@ -16,6 +16,7 @@
 package org.jboss.as.arquillian.container;
 
 import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTransformer;
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
 import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.arquillian.test.spi.TestEnricher;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
@@ -39,6 +40,7 @@ public class CommonContainerExtension implements LoadableExtension {
         builder.service(ResourceProvider.class, ArchiveDeployerProvider.class);
         builder.service(ResourceProvider.class, ManagementClientProvider.class);
         builder.service(TestEnricher.class, ContainerResourceTestEnricher.class);
+        builder.service(AuxiliaryArchiveAppender.class, CommonContainerArchiveAppender.class);
 
         builder.observer(ServerSetupObserver.class);
 

--- a/common/src/main/java/org/jboss/as/arquillian/container/ContainerResourceTestEnricher.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ContainerResourceTestEnricher.java
@@ -34,6 +34,7 @@ import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.test.spi.TestEnricher;
 import org.jboss.as.arquillian.api.ContainerResource;
+import org.wildfly.plugin.tools.server.ServerManager;
 
 /**
  * Test enricher that allows for injection of remote JNDI context into @RunAsClient test cases.
@@ -50,6 +51,9 @@ public class ContainerResourceTestEnricher implements TestEnricher {
 
     @Inject
     private Instance<ManagementClient> managementClient;
+
+    @Inject
+    private Instance<ServerManager> serverManager;
 
     /*
      * (non-Javadoc)
@@ -123,6 +127,8 @@ public class ContainerResourceTestEnricher implements TestEnricher {
                 return lookupContext(type, resource, qualifiers);
             } else if (ManagementClient.class.isAssignableFrom(type)) {
                 return managementClient.get();
+            } else if (ServerManager.class.isAssignableFrom(type)) {
+                return serverManager.get();
             } else {
                 throw new RuntimeException("@ContainerResource an unknown type " + resource.value());
 
@@ -176,9 +182,5 @@ public class ContainerResourceTestEnricher implements TestEnricher {
             }
         }
         return filtered.toArray(new Annotation[0]);
-    }
-
-    private interface ContainerResourceProvider {
-        Object lookup(Class<?> type, ContainerResource resource, Annotation... qualifiers);
     }
 }

--- a/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -83,7 +84,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
 import org.jboss.logging.Logger;
-import org.wildfly.common.Assert;
 
 /**
  * A helper class to join management related operations, like extract sub system ip/port (web/jmx)
@@ -131,10 +131,7 @@ public class ManagementClient implements Closeable {
 
     public ManagementClient(ModelControllerClient client, final String mgmtAddress, final int managementPort,
             final String protocol) {
-        if (client == null) {
-            throw new IllegalArgumentException("Client must be specified");
-        }
-        this.client = client;
+        this.client = Objects.requireNonNull(client, "Client must not be null");
         this.mgmtAddress = mgmtAddress;
         this.mgmtPort = managementPort;
         this.mgmtProtocol = protocol;
@@ -142,11 +139,7 @@ public class ManagementClient implements Closeable {
     }
 
     public ManagementClient(ModelControllerClient client, final CommonContainerConfiguration config) {
-        if (client == null) {
-            throw new IllegalArgumentException("Client must be specified");
-        }
-        Assert.checkNotNullParam("config", config);
-        this.client = client;
+        this.client = Objects.requireNonNull(client, "Client must not be null");
         this.mgmtAddress = config.getManagementAddress();
         this.mgmtPort = config.getManagementPort();
         this.mgmtProtocol = config.getManagementProtocol();

--- a/common/src/main/java/org/jboss/as/arquillian/container/ServerManagerProvider.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ServerManagerProvider.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.container;
+
+import java.lang.annotation.Annotation;
+
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.wildfly.plugin.tools.server.ServerManager;
+
+/**
+ * A provider for {@link ArquillianResource} injection of a {@link ServerManager}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ServerManagerProvider extends AbstractTargetsContainerProvider {
+
+    @Inject
+    private Instance<ServerManager> serverManager;
+
+    @Override
+    public boolean canProvide(final Class<?> type) {
+        return ServerManager.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public Object doLookup(final ArquillianResource resource, final Annotation... qualifiers) {
+        return serverManager.get();
+    }
+}

--- a/common/src/main/java/org/jboss/as/arquillian/setup/ConfigureLoggingSetupTask.java
+++ b/common/src/main/java/org/jboss/as/arquillian/setup/ConfigureLoggingSetupTask.java
@@ -1,0 +1,266 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.setup;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * A setup task for configuring loggers for tests.
+ * <p>
+ * You can define the log levels and logger names in two ways. The first is to pass a map of known logger levels with
+ * associated logger names to the {@linkplain ConfigureLoggingSetupTask#ConfigureLoggingSetupTask(Map) constructor}.
+ * The other is via a system property.
+ * </p>
+ * <p>
+ * To set the levels and logger names via a system property, use a key of {@code wildfly.logging.level.${level}} where
+ * {@code level} is one of the following:
+ * <ol>
+ * <li>all</li>
+ * <li>trace</li>
+ * <li>debug</li>
+ * <li>info</li>
+ * <li>warn</li>
+ * <li>error</li>
+ * <li>off</li>
+ * </ol>
+ *
+ * The value for each property is a comma delimited set of logger names.
+ * <p>
+ * Example:
+ *
+ * <pre>
+ *       {@code -Dwildfly.logging.level.debug=org.wildfly.security,org.jboss.resteasy}
+ *   </pre>
+ * </p>
+ * <p>
+ * When using the constructor, the map should consist of a known log level as the key and loggers to be associated with
+ * that level as the value of the map. Example:
+ *
+ * <pre>
+ *     {@code
+ *          public class WildFlyLoggingSetupTask extends ConfigurationLoggingSetupTask {
+ *              public WildFlyLoggingSetupTask() {
+ *                  super(Map.of("DEBUG", Set.of("org.wildfly.core", "org.wildfly"}));
+ *              }
+ *          }
+ *     )
+ * </pre>
+ *
+ * Note that when using the map constructor, you can still use the system property and the maps will be merged.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ConfigureLoggingSetupTask implements ServerSetupTask {
+    private final String handlerType;
+    private final String handlerName;
+    private final Map<String, Set<String>> logLevels;
+    private final BlockingDeque<ModelNode> tearDownOps;
+
+    /**
+     * Creates a new setup task which configures the {@code console-handler=CONSOLE} handler to allow all log levels.
+     * Then configures, either by modifying or adding, the loggers represented by the values from the system properties.
+     */
+    public ConfigureLoggingSetupTask() {
+        this(Map.of());
+    }
+
+    /**
+     * Creates a new setup task which configures the handler to allow all log levels. Then configures, either by
+     * modifying or adding, the loggers represented by system properties.
+     *
+     * @param handlerType the handler type which should be modified to ensure it allows all log levels, if {@code null}
+     *                        {@code console-handler} will be used
+     * @param handlerName the name of the handler which should be modified to ensure it allows all log levels, if {@code null}
+     *                        {@code console-handler} will be used
+     */
+    public ConfigureLoggingSetupTask(final String handlerType, final String handlerName) {
+        this(handlerType, handlerName, Map.of());
+    }
+
+    /**
+     * Creates a new setup task which configures the {@code console-handler=CONSOLE} handler to allow all log levels.
+     * Then configures, either by modifying or adding, the loggers represented by the values of the map passed in. The
+     * key of the map is the level desired for each logger.
+     * <p>
+     * The map consists of levels as the key and a set of logger names as the value for each level.
+     * </p>
+     *
+     * @param logLevels the map of levels and loggers
+     */
+    public ConfigureLoggingSetupTask(final Map<String, Set<String>> logLevels) {
+        this(null, null, logLevels);
+    }
+
+    /**
+     * Creates a new setup task which configures the handler to allow all log levels. Then configures, either by
+     * modifying or adding, the loggers represented by the values of the map passed in. The key of the map is the level
+     * desired for each logger.
+     * <p>
+     * If the {@code handlerType} is {@code null} the value will be {@code console-handler}. If the {@code handlerName}
+     * is {@code null} the value used will be {@code CONSOLE}.
+     * </p>
+     * <p>
+     * The map consists of levels as the key and a set of logger names as the value for each level.
+     * </p>
+     *
+     * @param handlerType the handler type which should be modified to ensure it allows all log levels, if {@code null}
+     *                        {@code console-handler} will be used
+     * @param handlerName the name of the handler which should be modified to ensure it allows all log levels, if {@code null}
+     *                        {@code console-handler} will be used
+     * @param logLevels   the map of levels and loggers
+     */
+    public ConfigureLoggingSetupTask(final String handlerType, final String handlerName,
+            final Map<String, Set<String>> logLevels) {
+        this.handlerType = handlerType == null ? "console-handler" : handlerType;
+        this.handlerName = handlerName == null ? "CONSOLE" : handlerName;
+        this.logLevels = createMap(logLevels);
+        this.tearDownOps = new LinkedBlockingDeque<>();
+    }
+
+    @Override
+    public void setup(final ManagementClient client, final String containerId) throws Exception {
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        ModelNode address = Operations.createAddress("subsystem", "logging", handlerType, handlerName);
+
+        // We need the current level to reset it when done
+        ModelNode currentValue = executeOp(client.getControllerClient(),
+                Operations.createReadAttributeOperation(address, "level"));
+        if (currentValue.isDefined()) {
+            tearDownOps.add(Operations.createWriteAttributeOperation(address, "level", currentValue.asString()));
+        }
+
+        builder.addStep(Operations.createUndefineAttributeOperation(address, "level"));
+        for (Map.Entry<String, Set<String>> entry : logLevels.entrySet()) {
+            for (String logger : entry.getValue()) {
+                if (logger.isBlank()) {
+                    address = Operations.createAddress("subsystem", "logging", "root-logger", "ROOT");
+                } else {
+                    address = Operations.createAddress("subsystem", "logging", "logger", logger);
+                }
+                builder.addStep(createLoggerOp(client.getControllerClient(), address, entry.getKey()));
+            }
+        }
+        executeOp(client.getControllerClient(), builder.build());
+    }
+
+    @Override
+    public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+        // Create a composite operation with all the tear-down operations
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        ModelNode removeOp;
+        while ((removeOp = tearDownOps.pollFirst()) != null) {
+            builder.addStep(removeOp);
+        }
+        executeOp(managementClient.getControllerClient(), builder.build());
+    }
+
+    private ModelNode createLoggerOp(final ModelControllerClient client, final ModelNode address, final String level)
+            throws IOException {
+        // First check if the logger exists
+        final ModelNode op = Operations.createReadResourceOperation(address);
+        final ModelNode result = client.execute(op);
+        if (Operations.isSuccessfulOutcome(result)) {
+            // Get the current level from te result
+            final ModelNode loggerConfig = Operations.readResult(result);
+            if (loggerConfig.hasDefined("level")) {
+                tearDownOps.add(Operations.createWriteAttributeOperation(address, "level", loggerConfig.get("level")
+                        .asString()));
+            }
+            return Operations.createWriteAttributeOperation(address, "level", level);
+        }
+        tearDownOps.add(Operations.createRemoveOperation(address));
+        final ModelNode addOp = Operations.createAddOperation(address);
+        addOp.get("level").set(level);
+        return addOp;
+    }
+
+    private ModelNode executeOp(final ModelControllerClient client, final ModelNode op) throws IOException {
+        return executeOp(client, Operation.Factory.create(op));
+    }
+
+    private ModelNode executeOp(final ModelControllerClient client, final Operation op) throws IOException {
+        final ModelNode result = client.execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            throw new RuntimeException(Operations.getFailureDescription(result).asString());
+        }
+        return Operations.readResult(result);
+    }
+
+    private static Map<String, Set<String>> createMap(final Map<String, Set<String>> toMerge) {
+        // We only allow a known set of levels
+        final Map<String, Set<String>> logLevels = new HashMap<>();
+        addLoggingConfig(logLevels, "all");
+        addLoggingConfig(logLevels, "trace");
+        addLoggingConfig(logLevels, "debug");
+        addLoggingConfig(logLevels, "info");
+        addLoggingConfig(logLevels, "warn");
+        addLoggingConfig(logLevels, "error");
+        addLoggingConfig(logLevels, "off");
+        return Map.copyOf(merge(logLevels, toMerge));
+    }
+
+    private static void addLoggingConfig(final Map<String, Set<String>> map, final String level) {
+        final String value = System.getProperty("wildfly.logging.level." + level);
+        if (value != null) {
+            final Set<String> names = Set.of(value.split(","));
+            if (!names.isEmpty()) {
+                map.put(level.toUpperCase(Locale.ROOT), names);
+            }
+        }
+    }
+
+    private static Map<String, Set<String>> merge(final Map<String, Set<String>> map1, final Map<String, Set<String>> map2) {
+        final Map<String, Set<String>> result = new HashMap<>();
+        for (var entry : map1.entrySet()) {
+            result.put(entry.getKey().toUpperCase(Locale.ROOT), entry.getValue());
+        }
+        for (final var entry : map2.entrySet()) {
+            if (entry.getValue().isEmpty()) {
+                continue;
+            }
+            final String key = entry.getKey().toUpperCase(Locale.ROOT);
+            if (result.containsKey(key)) {
+                result.put(key,
+                        Stream.concat(result.get(key).stream(), entry.getValue().stream())
+                                .collect(Collectors.toSet()));
+            } else {
+                result.put(key, Set.copyOf(entry.getValue()));
+            }
+        }
+        return Map.copyOf(result);
+    }
+}

--- a/common/src/main/java/org/jboss/as/arquillian/setup/ReloadServerSetupTask.java
+++ b/common/src/main/java/org/jboss/as/arquillian/setup/ReloadServerSetupTask.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.setup;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.wildfly.plugin.tools.server.ServerManager;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings({ "unused", "RedundantThrows" })
+public class ReloadServerSetupTask implements ServerSetupTask {
+
+    @ArquillianResource
+    private ServerManager serverManager;
+
+    @Override
+    public final void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+        try {
+            doSetup(managementClient, containerId);
+        } finally {
+            serverManager.reloadIfRequired();
+        }
+    }
+
+    @Override
+    public final void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+        try {
+            doTearDown(managementClient, containerId);
+        } finally {
+            serverManager.reloadIfRequired();
+        }
+    }
+
+    /**
+     * Execute any necessary setup work that needs to happen before the first deployment to the given container.
+     *
+     * @param client      management client to use to interact with the container
+     * @param containerId id of the container to which the deployment will be deployed
+     *
+     * @throws Exception if a failure occurs
+     * @see #setup(ManagementClient, String)
+     */
+    protected void doSetup(final ManagementClient client, final String containerId) throws Exception {
+    }
+
+    /**
+     * Execute any tear down work that needs to happen after the last deployment associated
+     * with the given container has been undeployed.
+     *
+     * @param managementClient management client to use to interact with the container
+     * @param containerId      id of the container to which the deployment will be deployed
+     *
+     * @throws Exception if a failure occurs
+     * @see #tearDown(ManagementClient, String)
+     */
+    protected void doTearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+    }
+}

--- a/common/src/main/java/org/jboss/as/arquillian/setup/SnapshotServerSetupTask.java
+++ b/common/src/main/java/org/jboss/as/arquillian/setup/SnapshotServerSetupTask.java
@@ -1,0 +1,158 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.arquillian.setup;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.wildfly.plugin.tools.server.ServerManager;
+
+/**
+ * A setup task which takes a snapshot of the current configuration. It then invokes the
+ * {@link #doSetup(ManagementClient, String)} which allows configuration of the running server. On
+ * {@link #tearDown(ManagementClient, String)} the snapshot server configuration is used to reload the server and
+ * overwrite the current configuration.
+ * <p>
+ * This setup tasks should be the first setup tasks if used with other setup tasks. Otherwise, the snapshot will have
+ * changes from the previous setup tasks.
+ * <p>
+ * <p>
+ * Note that if during the setup the server gets in a state of {@code reload-required}, then the after the
+ * {@link #doSetup(ManagementClient, String)} is executed a reload will happen automatically.
+ * </p>
+ * <p>
+ * If the {@link #doSetup(ManagementClient, String)} fails, the {@link #tearDown(ManagementClient, String)} method will
+ * be invoked.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings({ "unused", "RedundantThrows" })
+public class SnapshotServerSetupTask implements ServerSetupTask {
+    private static final Logger LOGGER = Logger.getLogger(SnapshotServerSetupTask.class);
+
+    private final Map<String, AutoCloseable> snapshots = new ConcurrentHashMap<>();
+
+    @ArquillianResource
+    private ServerManager serverManager;
+
+    @Override
+    public final void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+        try {
+            final String fileName = serverManager.takeSnapshot();
+            final AutoCloseable restorer = () -> {
+                final ModelNode op = Operations.createOperation("reload");
+                op.get("server-config").set(fileName);
+                serverManager.executeReload(op);
+                serverManager.waitFor(timeout(), TimeUnit.SECONDS);
+                @SuppressWarnings("resource")
+                final ModelNode result1 = serverManager.client().execute(Operations.createOperation("write-config"));
+                if (!Operations.isSuccessfulOutcome(result1)) {
+                    throw new RuntimeException(
+                            "Failed to write config after restoring from snapshot " + Operations.getFailureDescription(result1)
+                                    .asString());
+                }
+            };
+            snapshots.put(containerId, restorer);
+            try {
+                doSetup(managementClient, containerId);
+            } catch (Throwable e) {
+                try {
+                    restorer.close();
+                } catch (Throwable t) {
+                    LOGGER.warnf(t, "Failed to restore snapshot for %s: %s", getClass().getName(), fileName);
+                }
+                throw e;
+            }
+        } finally {
+            serverManager.reloadIfRequired(timeout(), TimeUnit.SECONDS);
+        }
+    }
+
+    @Override
+    public final void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+        try {
+            beforeRestore(managementClient, containerId);
+        } finally {
+            try {
+                final AutoCloseable snapshot = snapshots.remove(containerId);
+                if (snapshot != null) {
+                    snapshot.close();
+                }
+            } finally {
+                nonManagementCleanUp();
+            }
+        }
+    }
+
+    /**
+     * Execute any necessary setup work that needs to happen before the first deployment to the given container.
+     * <p>
+     * If this method throws an exception, the {@link #tearDown(ManagementClient, String)} method will be invoked.
+     * </p>
+     *
+     * @param managementClient management client to use to interact with the container
+     * @param containerId      id of the container to which the deployment will be deployed
+     *
+     * @throws Exception if a failure occurs
+     * @see #setup(ManagementClient, String)
+     */
+    protected void doSetup(final ManagementClient managementClient, final String containerId) throws Exception {
+    }
+
+    /**
+     * Execute any necessary work required before the restore is completed. As an example removing a messaging queue
+     * which triggers removing the queue from a remote server.
+     *
+     * @param managementClient management client to use to interact with the container
+     * @param containerId      id of the container to which the deployment will be deployed
+     *
+     * @throws Exception if a failure occurs
+     * @see #tearDown(ManagementClient, String)
+     */
+    protected void beforeRestore(final ManagementClient managementClient, final String containerId) throws Exception {
+    }
+
+    /**
+     * Allows for cleaning up resources that may have been created during the setup. This is always executed even if the
+     * {@link #doSetup(ManagementClient, String)} fails for some reason.
+     *
+     * @throws Exception if a failure occurs
+     */
+    protected void nonManagementCleanUp() throws Exception {
+    }
+
+    /**
+     * The number seconds to wait for the server to reload after the server configuration has been restored or if a
+     * reload was required in the {@link #doSetup(ManagementClient, String)}.
+     *
+     * @return the number of seconds to wait for a reload, the default is 10 seconds
+     */
+    protected long timeout() {
+        return 10L;
+    }
+}

--- a/container-managed/pom.xml
+++ b/container-managed/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>wildfly-arquillian-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-plugin-tools</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>

--- a/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/AppClientWrapper.java
+++ b/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/AppClientWrapper.java
@@ -35,7 +35,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.jboss.as.arquillian.container.ParameterUtils;
 import org.jboss.logging.Logger;
-import org.wildfly.plugin.tools.ServerHelper;
+import org.wildfly.plugin.tools.server.ServerManager;
 
 /**
  * A wrapper for an application client process. Allows interacting with the application client process.
@@ -189,7 +189,7 @@ public class AppClientWrapper implements AutoCloseable {
         final String jbossHome = config.getJbossHome();
         if (jbossHome == null)
             throw new IllegalArgumentException("jbossHome config property is not set.");
-        if (!ServerHelper.isValidHomeDirectory(jbossHome))
+        if (!ServerManager.isValidHomeDirectory(jbossHome))
             throw new IllegalArgumentException("Server directory from config jbossHome doesn't exist: " + jbossHome);
 
         final String archiveArg = String.format("%s#%s", archivePath, clientArchiveName);

--- a/integration-tests/junit5-tests/pom.xml
+++ b/integration-tests/junit5-tests/pom.xml
@@ -70,6 +70,11 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-junit-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/InContainerTestAssertion.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/InContainerTestAssertion.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public interface InContainerTestAssertion {
+
+    @Test
+    default void checkInContainer() {
+        final PrivilegedAction<Object> action = () -> {
+            final var caller = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
+                    .getCallerClass();
+            // We should be a modular class loader and the name should be something line deployment.${archive}
+            Assertions.assertNotNull(caller.getClassLoader());
+            Assertions.assertTrue(caller.getClassLoader().toString().contains("deployment."));
+            return null;
+        };
+        if (System.getSecurityManager() == null) {
+            action.run();
+        } else {
+            AccessController.doPrivileged(action);
+        }
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/InContainerTestCase.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/InContainerTestCase.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @ExtendWith(ArquillianExtension.class)
 @ServerSetup(InContainerTestCase.SystemPropertyServerSetupTask.class)
-public class InContainerTestCase {
+public class InContainerTestCase implements InContainerTestAssertion {
 
     private static final Map<String, String> PROPERTIES = new HashMap<>();
 
@@ -61,7 +61,7 @@ public class InContainerTestCase {
     @Deployment
     public static JavaArchive create() {
         return ShrinkWrap.create(JavaArchive.class)
-                .addClass(Greeter.class)
+                .addClasses(Greeter.class, InContainerTestAssertion.class)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/ServerManagerInjectionTestCase.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/ServerManagerInjectionTestCase.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.server;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.wildfly.arquillian.junit.annotations.WildFlyArquillian;
+import org.wildfly.plugin.tools.server.ServerManager;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@WildFlyArquillian
+@RunAsClient
+public class ServerManagerInjectionTestCase {
+
+    @ArquillianResource
+    private ServerManager serverManager;
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class, "server-manager-injection.war")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void checkInjected() {
+        Assertions.assertNotNull(serverManager, "The server manager should have been injected.");
+    }
+
+    @Test
+    public void checkRunning() {
+        Assertions.assertTrue(serverManager.isRunning(), "The server should be running");
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/ReloadServerSetupTaskTestCase.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/ReloadServerSetupTaskTestCase.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.server.setup;
+
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.arquillian.setup.ReloadServerSetupTask;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.wildfly.arquillian.junit.annotations.WildFlyArquillian;
+import org.wildfly.plugin.tools.server.ServerManager;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@WildFlyArquillian
+@RunAsClient
+@ServerSetup(ReloadServerSetupTaskTestCase.TestSetupTask.class)
+public class ReloadServerSetupTaskTestCase {
+
+    public static class TestSetupTask extends ReloadServerSetupTask {
+        private final ModelNode address = Operations.createAddress("subsystem", "remoting");
+        private final String attributeName = "max-inbound-channels";
+        private volatile int currentValue;
+
+        @ContainerResource
+        private ServerManager serverManager;
+
+        @Override
+        protected void doSetup(final ManagementClient client, final String containerId) throws Exception {
+            currentValue = executeOperation(client, Operations.createReadAttributeOperation(address, attributeName)).asInt();
+            // Increase the current value which should put the server in a state of reload-required
+            executeOperation(client, Operations.createWriteAttributeOperation(address, attributeName, currentValue + 10));
+            // Check the server state is in a reload required state
+            Assertions.assertEquals(ClientConstants.CONTROLLER_PROCESS_STATE_RELOAD_REQUIRED, serverManager.serverState());
+        }
+
+        @Override
+        protected void doTearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+            // Reset the old value
+            executeOperation(managementClient, Operations.createWriteAttributeOperation(address, attributeName, currentValue));
+            // Check the server state is in a reload required state
+            Assertions.assertEquals(ClientConstants.CONTROLLER_PROCESS_STATE_RELOAD_REQUIRED, serverManager.serverState());
+        }
+    }
+
+    @ContainerResource
+    private static ManagementClient client;
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @AfterAll
+    public static void checkControllerState() throws Exception {
+        // Check the server state is in a reload required state
+        checkServerStateIsRunning();
+    }
+
+    @Test
+    public void checkServerReloaded() throws Exception {
+        // Check the server state is not in a reload required state
+        checkServerStateIsRunning();
+    }
+
+    private static void checkServerStateIsRunning() throws IOException {
+        final ModelNode op = Operations.createReadAttributeOperation(new ModelNode().setEmptyList(), "server-state");
+        final ModelNode result = client.getControllerClient().execute(op);
+        if (Operations.isSuccessfulOutcome(result)) {
+            Assertions.assertEquals(ClientConstants.CONTROLLER_PROCESS_STATE_RUNNING, Operations.readResult(result)
+                    .asString());
+        } else {
+            Assertions.fail("Checking the server state failed: " + Operations.getFailureDescription(result).asString());
+        }
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/SetupTaskTestCase.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/SetupTaskTestCase.java
@@ -1,0 +1,160 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.server.setup;
+
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.EventConditions;
+import org.junit.platform.testkit.engine.TestExecutionResultConditions;
+import org.wildfly.arquillian.junit.annotations.WildFlyArquillian;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@WildFlyArquillian
+@RunAsClient
+public class SetupTaskTestCase {
+
+    @ArquillianResource
+    private ManagementClient client;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "setup-task-test.war")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @BeforeEach
+    public void clearSystemProperties() throws Exception {
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        for (ModelNode name : getSystemProperties()) {
+            final ModelNode address = Operations.createAddress("system-property", name.asString());
+            builder.addStep(Operations.createRemoveOperation(address));
+        }
+        executeOperation(builder.build());
+    }
+
+    @Test
+    public void successThenAssertionFail() throws Exception {
+        final var results = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(SetupTaskTests.SuccessThenAssertionFail.class))
+                .execute();
+        // No tests should have been executed
+        final var testEvents = results.testEvents();
+        testEvents.assertThatEvents().isEmpty();
+        // We should have one failure from the setup task
+        final var events = results.allEvents();
+        events.assertStatistics((stats) -> stats.failed(1L));
+        events.assertThatEvents()
+                .haveAtLeastOne(EventConditions.event(
+                        EventConditions.finishedWithFailure(TestExecutionResultConditions.instanceOf(AssertionError.class))));
+        assertOnlyProperties(SetupTaskTests.AssertionErrorSetupTask.PROPERTY_NAME);
+    }
+
+    @Test
+    public void successThenRuntimeFail() throws Exception {
+        final var results = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(SetupTaskTests.SuccessThenRuntimeFail.class))
+                .execute();
+        // No tests should have been executed
+        final var testEvents = results.testEvents();
+        testEvents.assertThatEvents().isEmpty();
+        // We should have one failure from the setup task
+        final var events = results.allEvents();
+        events.assertStatistics((stats) -> stats.failed(1L));
+        events.assertThatEvents()
+                .haveAtLeastOne(EventConditions.event(
+                        EventConditions.finishedWithFailure(TestExecutionResultConditions.instanceOf(RuntimeException.class))));
+        assertOnlyProperties(SetupTaskTests.RuntimeExceptionSetupTask.PROPERTY_NAME);
+    }
+
+    @Test
+    public void successAndAfter() throws Exception {
+        final var results = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectMethod(SetupTaskTests.SuccessAndAfter.class, "systemPropertiesExist"))
+                .execute();
+        // The test should have been successful
+        final var testEvents = results.testEvents();
+        testEvents.assertThatEvents().haveExactly(1, EventConditions.finishedSuccessfully());
+        // All properties should have been removed in the SetupServerTask.tearDown()
+        assertNoSystemProperties();
+    }
+
+    private void assertOnlyProperties(final String... names) throws IOException {
+        final Set<String> expectedNames = Set.of(names);
+        final Set<String> allProperties = getSystemProperties()
+                .stream()
+                .map(ModelNode::asString)
+                .collect(Collectors.toCollection(LinkedHashSet<String>::new));
+        Assertions.assertTrue(allProperties.containsAll(expectedNames), () -> String
+                .format("The following properties were expected in \"%s\", but not found; %s", allProperties, expectedNames));
+        // Remove the expected properties
+        allProperties.removeAll(expectedNames);
+        Assertions.assertTrue(allProperties.isEmpty(),
+                () -> String.format("The following properties exist which should not exist: %s", allProperties));
+    }
+
+    private void assertNoSystemProperties() throws IOException {
+        final ModelNode op = Operations.createOperation("read-children-names");
+        op.get(ClientConstants.CHILD_TYPE).set("system-property");
+        final ModelNode result = executeOperation(op);
+        Assertions.assertTrue(result.asList()
+                .isEmpty(), () -> "Expected no system properties, found: " + result.asString());
+    }
+
+    private List<ModelNode> getSystemProperties() throws IOException {
+        final ModelNode op = Operations.createOperation("read-children-names");
+        op.get(ClientConstants.CHILD_TYPE).set("system-property");
+        return executeOperation(op).asList();
+    }
+
+    private ModelNode executeOperation(final ModelNode op) throws IOException {
+        return executeOperation(Operation.Factory.create(op));
+    }
+
+    private ModelNode executeOperation(final Operation op) throws IOException {
+        final ModelNode result = client.getControllerClient().execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            Assertions.fail("Operation has failed: " + Operations.getFailureDescription(result).asString());
+        }
+        return Operations.readResult(result);
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/SetupTaskTests.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/SetupTaskTests.java
@@ -1,0 +1,162 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.server.setup;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.wildfly.arquillian.junit.annotations.WildFlyArquillian;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@WildFlyArquillian
+@RunAsClient
+abstract class SetupTaskTests {
+
+    public static class SuccessfulSetupTask extends SystemPropertyServerSetupTask implements ServerSetupTask {
+        public static final String PROPERTY_NAME = "wildfly.arquillian.test.success";
+
+        public SuccessfulSetupTask() {
+            super(Map.of(PROPERTY_NAME, "true"));
+        }
+    }
+
+    public static class AfterSuccessfulSetupTask extends SystemPropertyServerSetupTask implements ServerSetupTask {
+        public static final String PROPERTY_NAME = "wildfly.arquillian.test.success.after";
+
+        public AfterSuccessfulSetupTask() {
+            super(Map.of(PROPERTY_NAME, "true"));
+        }
+    }
+
+    public static class RuntimeExceptionSetupTask extends SystemPropertyServerSetupTask implements ServerSetupTask {
+        public static final String PROPERTY_NAME = "wildfly.arquillian.test.runtime.exception";
+
+        public RuntimeExceptionSetupTask() {
+            super(Map.of(PROPERTY_NAME, "true"));
+        }
+
+        @Override
+        public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+            super.setup(managementClient, containerId);
+            throw new RuntimeException("RuntimeException failed on purpose");
+        }
+    }
+
+    public static class AssertionErrorSetupTask extends SystemPropertyServerSetupTask implements ServerSetupTask {
+        public static final String PROPERTY_NAME = "wildfly.arquillian.test.assertion.error";
+
+        public AssertionErrorSetupTask() {
+            super(Map.of(PROPERTY_NAME, "true"));
+        }
+
+        @Override
+        public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+            super.setup(managementClient, containerId);
+            Assertions.fail("AssertionError failed on purpose");
+        }
+    }
+
+    @ArquillianResource
+    private ManagementClient client;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "inner-setup-task-tests.war")
+                .addClasses(SetupTaskTestCase.class,
+                        SuccessfulSetupTask.class,
+                        RuntimeExceptionSetupTask.class,
+                        AssertionErrorSetupTask.class);
+    }
+
+    @Test
+    public void failIfExecuted(final TestInfo testInfo) {
+        Assertions.fail(String.format("Test %s.%s should not have been executed.",
+                testInfo.getTestClass().map(Class::getName).orElse("Unknown"),
+                testInfo.getTestMethod().map(Method::getName).orElse("Unknown")));
+    }
+
+    @Test
+    public void systemPropertiesExist() throws Exception {
+        final Set<String> properties = getSystemProperties()
+                .stream()
+                .map(ModelNode::asString)
+                .collect(Collectors.toCollection(TreeSet::new));
+        Assertions.assertIterableEquals(
+                new TreeSet<>(Set.of(SuccessfulSetupTask.PROPERTY_NAME, AfterSuccessfulSetupTask.PROPERTY_NAME)), properties);
+    }
+
+    private List<ModelNode> getSystemProperties() throws IOException {
+        final ModelNode op = Operations.createOperation("read-children-names");
+        op.get(ClientConstants.CHILD_TYPE).set("system-property");
+        return executeOperation(op).asList();
+    }
+
+    private ModelNode executeOperation(final ModelNode op) throws IOException {
+        final ModelNode result = client.getControllerClient().execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            Assertions.fail("Operation has failed: " + Operations.getFailureDescription(result).asString());
+        }
+        return Operations.readResult(result);
+    }
+
+    @ServerSetup({
+            SuccessfulSetupTask.class,
+            RuntimeExceptionSetupTask.class,
+            AfterSuccessfulSetupTask.class
+    })
+    public static class SuccessThenRuntimeFail extends SetupTaskTests {
+    }
+
+    @ServerSetup({
+            SuccessfulSetupTask.class,
+            AssertionErrorSetupTask.class,
+            AfterSuccessfulSetupTask.class
+    })
+    public static class SuccessThenAssertionFail extends SetupTaskTests {
+    }
+
+    @ServerSetup({
+            SuccessfulSetupTask.class,
+            AfterSuccessfulSetupTask.class
+    })
+    public static class SuccessAndAfter extends SetupTaskTests {
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/SnapshotSetupTaskTestCase.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/SnapshotSetupTaskTestCase.java
@@ -1,0 +1,173 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.server.setup;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.arquillian.setup.SnapshotServerSetupTask;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.EventConditions;
+import org.junit.platform.testkit.engine.TestExecutionResultConditions;
+import org.wildfly.arquillian.junit.annotations.WildFlyArquillian;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@WildFlyArquillian
+@RunAsClient
+public class SnapshotSetupTaskTestCase {
+    private static final String PROPERTY_NAME = SnapshotServerSetupTask.class.getName();
+    private static final ModelNode ADDRESS = Operations.createAddress("system-property", PROPERTY_NAME);
+    private static final Path TEST_FILE = Path.of(System.getProperty("java.io.tmpdir"), "snapshot-test-file.txt");
+
+    @ArquillianResource
+    private ManagementClient client;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "snapshot-setup-task-test.war")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void checkSnapshotRestored() throws Exception {
+        final var results = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(SuccessfulSnapshotTests.class))
+                .execute();
+        // Two tests should have been executed successfully
+        final var testEvents = results.testEvents();
+        testEvents.assertThatEvents().haveExactly(2, EventConditions.finishedSuccessfully());
+        checkSystemProperty(client, false);
+        Assertions.assertTrue(Files.notExists(TEST_FILE),
+                "The test file should have been cleaned up in the nonManagementCleanup()");
+    }
+
+    @Test
+    public void checkSnapshotRestoredRollback() throws Exception {
+        final var results = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(RollbackSnapshotTests.class))
+                .execute();
+        // No tests should have been executed
+        final var testEvents = results.testEvents();
+        testEvents.assertThatEvents().isEmpty();
+        // We should have one failure from the setup task
+        final var events = results.allEvents();
+        events.assertStatistics((stats) -> stats.failed(1L));
+        events.assertThatEvents()
+                .haveAtLeastOne(EventConditions.event(
+                        EventConditions.finishedWithFailure(TestExecutionResultConditions.instanceOf(AssertionError.class))));
+        checkSystemProperty(client, false);
+    }
+
+    private static void checkSystemProperty(final ManagementClient client, final boolean expectSuccess) throws IOException {
+        final ModelNode op = Operations.createReadAttributeOperation(ADDRESS, "value");
+        final ModelNode result = client.getControllerClient().execute(op);
+        final Supplier<String> msg;
+        if (expectSuccess) {
+            msg = () -> "Getting the system property failed: " + Operations.getFailureDescription(result)
+                    .asString();
+        } else {
+            msg = () -> String.format("Expected system property %s to not exist.", PROPERTY_NAME);
+        }
+        Assertions.assertTrue((expectSuccess == Operations.isSuccessfulOutcome(result)), msg);
+    }
+
+    public static class TestSystemPropertySetupTask extends SnapshotServerSetupTask {
+        @Override
+        protected void doSetup(final ManagementClient managementClient, final String containerId) throws Exception {
+            final ModelNode op = Operations.createAddOperation(ADDRESS);
+            op.get("value").set("present");
+            executeOperation(managementClient, op);
+            Files.createFile(TEST_FILE);
+        }
+
+        @Override
+        protected void nonManagementCleanUp() throws Exception {
+            Files.delete(TEST_FILE);
+        }
+    }
+
+    public static class ErrorSetupTask extends SnapshotServerSetupTask {
+        @Override
+        protected void doSetup(final ManagementClient managementClient, final String containerId) throws Exception {
+            final ModelNode op = Operations.createAddOperation(ADDRESS);
+            op.get("value").set("present");
+            executeOperation(managementClient, op);
+            Files.createFile(TEST_FILE);
+            Assertions.fail("Failed on purpose");
+        }
+
+        @Override
+        protected void nonManagementCleanUp() throws Exception {
+            Files.delete(TEST_FILE);
+        }
+    }
+
+    @WildFlyArquillian
+    @RunAsClient
+    public abstract static class SnapshotTests {
+
+        @ArquillianResource
+        private ManagementClient client;
+
+        @Deployment(testable = false)
+        public static WebArchive createDeployment() {
+            return ShrinkWrap.create(WebArchive.class, "inner-snapshot-setup-task-test.war")
+                    .addClass(SnapshotServerSetupTask.class)
+                    .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        }
+
+        @Test
+        public void systemPropertyExists() throws Exception {
+            checkSystemProperty(client, true);
+        }
+
+        @Test
+        public void fileExists() {
+            Assertions.assertTrue(Files.exists(TEST_FILE), () -> "Expected test file to exist: " + TEST_FILE);
+        }
+    }
+
+    @ServerSetup(TestSystemPropertySetupTask.class)
+    public static class SuccessfulSnapshotTests extends SnapshotTests {
+
+    }
+
+    @ServerSetup(ErrorSetupTask.class)
+    public static class RollbackSnapshotTests extends SnapshotTests {
+
+    }
+}

--- a/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/SystemPropertyServerSetupTask.java
+++ b/integration-tests/junit5-tests/src/test/java/org/wildfly/arquillian/integration/test/junit5/server/setup/SystemPropertyServerSetupTask.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.arquillian.integration.test.junit5.server.setup;
+
+import java.util.Map;
+
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class SystemPropertyServerSetupTask implements ServerSetupTask {
+    public final Map<String, String> properties;
+
+    public SystemPropertyServerSetupTask(final Map<String, String> properties) {
+        this.properties = Map.copyOf(properties);
+    }
+
+    @Override
+    public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+        final Operations.CompositeOperationBuilder builder = Operations.CompositeOperationBuilder.create();
+        for (var entry : properties.entrySet()) {
+            final ModelNode address = Operations.createAddress("system-property", entry.getKey());
+            final ModelNode op = Operations.createAddOperation(address);
+            op.get("value").set(entry.getValue());
+            builder.addStep(op);
+        }
+        executeOperation(managementClient, builder.build());
+    }
+
+    @Override
+    public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+        final Operations.CompositeOperationBuilder builder = Operations.CompositeOperationBuilder.create();
+        for (var entry : properties.entrySet()) {
+            final ModelNode address = Operations.createAddress("system-property", entry.getKey());
+            builder.addStep(Operations.createRemoveOperation(address));
+        }
+        executeOperation(managementClient, builder.build());
+    }
+}

--- a/integration-tests/junit5-tests/src/test/resources/arquillian.xml
+++ b/integration-tests/junit5-tests/src/test/resources/arquillian.xml
@@ -22,7 +22,8 @@
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
             <property name="javaVmArguments">${debug.vm.args} ${jvm.args}</property>
-            <property name="allowConnectingToRunningServer">false</property>
+            <!-- This is needed for cases where we need to use the EngineTestKit -->
+            <property name="allowConnectingToRunningServer">true</property>
         </configuration>
     </container>
 </arquillian>

--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,12 @@
         <version.org.jboss.remotingjmx.remoting-jmx>3.1.0.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <!-- Required by Elytron dependencies -->
         <version.org.slf4j>1.7.36</version.org.slf4j>
-        <version.org.wildfly.common.wildfly-common>1.7.0.Final</version.org.wildfly.common.wildfly-common>
         <version.org.wildfly.plugins.wildfly-jar-maven-plugin>11.0.0.Beta2</version.org.wildfly.plugins.wildfly-jar-maven-plugin>
         <version.org.wildfly.plugins.wildfly-maven-plugin>5.0.0.Final</version.org.wildfly.plugins.wildfly-maven-plugin>
-        <version.org.wildfly.plugins.wildfly-plugin-tools>1.0.0.Beta4</version.org.wildfly.plugins.wildfly-plugin-tools>
+        <version.org.wildfly.plugins.wildfly-plugin-tools>1.1.0.Final</version.org.wildfly.plugins.wildfly-plugin-tools>
 
         <!-- keep this in sync with version that is used in arquillian -->
+        <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
         <version.org.jboss.shrinkwrap.descriptors>2.0.0</version.org.jboss.shrinkwrap.descriptors>
         <version.org.jboss.ejb-client>4.0.54.Final</version.org.jboss.ejb-client>
         <version.org.testng>7.7.0</version.org.testng>
@@ -278,6 +278,7 @@
         </plugins>
     </build>
     <modules>
+        <module>wildfly-testing-tools</module>
         <module>common</module>
         <module>container-bootable</module>
         <module>container-embedded</module>
@@ -308,6 +309,13 @@
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-bom</artifactId>
                 <version>${version.org.jboss.resteasy}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-bom</artifactId>
+                <version>${version.org.jboss.shrinkwrap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -554,6 +562,11 @@
 
             <dependency>
                 <groupId>org.wildfly.arquillian</groupId>
+                <artifactId>wildfly-testing-tools</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.arquillian</groupId>
                 <artifactId>wildfly-arquillian-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -606,11 +619,6 @@
                 <groupId>org.wildfly.arquillian</groupId>
                 <artifactId>wildfly-arquillian-testenricher-msc</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wildfly.common</groupId>
-                <artifactId>wildfly-common</artifactId>
-                <version>${version.org.wildfly.common.wildfly-common}</version>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -594,6 +594,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly.arquillian</groupId>
+                <artifactId>wildfly-arquillian-junit-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.arquillian</groupId>
                 <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/wildfly-testing-tools/pom.xml
+++ b/wildfly-testing-tools/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2024 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wildfly.arquillian</groupId>
+        <artifactId>wildfly-arquillian-parent</artifactId>
+        <version>5.1.0.Beta2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wildfly-testing-tools</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-plugin-tools</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/wildfly-testing-tools/src/main/java/org/wildfly/testing/tools/deployments/DeploymentDescriptors.java
+++ b/wildfly-testing-tools/src/main/java/org/wildfly/testing/tools/deployments/DeploymentDescriptors.java
@@ -1,0 +1,378 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.testing.tools.deployments;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FilePermission;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.Permission;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
+import org.jboss.shrinkwrap.api.container.WebContainer;
+
+/**
+ * A utility to generate various deployment descriptors.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("unused")
+public class DeploymentDescriptors {
+
+    private DeploymentDescriptors() {
+    }
+
+    /**
+     * Adds a {@code jboss-deployment-structure.xml} file to a deployment with optional dependency additions or
+     * exclusions.
+     *
+     * @param archive         the archive to add the {@code jboss-deployment-structure.xml} to
+     * @param addedModules    the modules to add to an archive or an empty set
+     * @param excludedModules the modules to exclude from an archive or an empty set
+     * @param <T>             the archive type
+     *
+     * @return the archive
+     */
+    public static <T extends WebContainer<T> & Archive<T>> T addJBossDeploymentStructure(final T archive,
+            final Set<String> addedModules, final Set<String> excludedModules) {
+        return archive.addAsWebInfResource(createJBossDeploymentStructureAsset(addedModules, excludedModules),
+                "jboss-deployment-structure.xml");
+    }
+
+    /**
+     * Creates a {@code jboss-deployment-structure.xml} file with the optional dependency additions or exclusions.
+     *
+     * @param addedModules    the modules to add or an empty set
+     * @param excludedModules the modules to exclude or an empty set
+     *
+     * @return a {@code jboss-deployment-structure.xml} asset
+     */
+    public static Asset createJBossDeploymentStructureAsset(final Set<String> addedModules, final Set<String> excludedModules) {
+        return new ByteArrayAsset(createJBossDeploymentStructure(addedModules, excludedModules));
+    }
+
+    /**
+     * Creates a {@code jboss-deployment-structure.xml} file with the optional dependency additions or exclusions.
+     *
+     * @param addedModules    the modules to add or an empty set
+     * @param excludedModules the modules to exclude or an empty set
+     *
+     * @return a {@code jboss-deployment-structure.xml} in a byte array
+     */
+    public static byte[] createJBossDeploymentStructure(final Set<String> addedModules, final Set<String> excludedModules) {
+        XMLStreamWriter writer = null;
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            writer = createWriter(out);
+
+            writer.writeStartDocument("utf-8", "1.0");
+            writer.writeStartElement("jboss-deployment-structure");
+
+            writer.writeStartElement("deployment");
+
+            if (!addedModules.isEmpty()) {
+                writer.writeStartElement("dependencies");
+                for (String module : addedModules) {
+                    writer.writeStartElement("module");
+                    writer.writeAttribute("name", module);
+                    writer.writeEndElement();
+                }
+                writer.writeEndElement();
+            }
+            if (!excludedModules.isEmpty()) {
+                writer.writeStartElement("exclusions");
+                for (String module : addedModules) {
+                    writer.writeStartElement("module");
+                    writer.writeAttribute("name", module);
+                    writer.writeEndElement();
+                }
+                writer.writeEndElement();
+            }
+
+            writer.writeEndElement();
+
+            writer.writeEndElement();
+            writer.writeEndDocument();
+            writer.flush();
+            return out.toByteArray();
+        } catch (IOException | XMLStreamException e) {
+            throw new RuntimeException("Failed to create the jboss-deployment-structure.xml file.", e);
+        } finally {
+            if (writer != null)
+                try {
+                    writer.close();
+                } catch (Exception ignore) {
+
+                }
+        }
+    }
+
+    /**
+     * Creates a {@code jboss-web.xml} with the context root provided.
+     *
+     * @param contextRoot the context root to use for the deployment
+     *
+     * @return a {@code jboss-web.xml}
+     */
+    public static Asset createJBossWebContextRoot(final String contextRoot) {
+        return createJBossWebXmlAsset(Map.of("context-root", contextRoot));
+    }
+
+    /**
+     * Creates a {@code jboss-web.xml} with the security domain for the deployment.
+     *
+     * @param securityDomain the security domain to use for the deployment
+     *
+     * @return a {@code jboss-web.xml}
+     */
+    public static Asset createJBossWebSecurityDomain(final String securityDomain) {
+        return createJBossWebXmlAsset(Map.of("security-domain", securityDomain));
+    }
+
+    /**
+     * Creates a {@code jboss-web.xml} with simple attributes.
+     *
+     * @param elements the elements to add where the key is the element name and the value is the elements value
+     *
+     * @return a {@code jboss-web.xml}
+     */
+    public static Asset createJBossWebXmlAsset(final Map<String, String> elements) {
+        return new ByteArrayAsset(createJBossWebXml(elements));
+    }
+
+    /**
+     * Creates a {@code jboss-web.xml} with simple attributes.
+     *
+     * @param elements the elements to add where the key is the element name and the value is the elements value
+     *
+     * @return a {@code jboss-web.xml}
+     */
+    public static byte[] createJBossWebXml(final Map<String, String> elements) {
+        XMLStreamWriter writer = null;
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            writer = createWriter(out);
+
+            writer.writeStartDocument("utf-8", "1.0");
+            writer.writeStartElement("jboss-web");
+
+            for (var element : elements.entrySet()) {
+                writer.writeStartElement(element.getKey());
+                writer.writeCharacters(element.getValue());
+                writer.writeEndElement();
+            }
+
+            writer.writeEndElement();
+            writer.writeEndDocument();
+            writer.flush();
+            return out.toByteArray();
+        } catch (IOException | XMLStreamException e) {
+            throw new RuntimeException("Failed to create the jboss-deployment-structure.xml file.", e);
+        } finally {
+            if (writer != null)
+                try {
+                    writer.close();
+                } catch (Exception ignore) {
+
+                }
+        }
+    }
+
+    /**
+     * Creates a new asset with the given contents for a {@code permissions.xml} file.
+     *
+     * @param permissions the permissions to add to the file
+     *
+     * @return an asset with the given contents for a {@code permissions.xml} file
+     */
+    public static Asset createPermissionsXmlAsset(Permission... permissions) {
+        return new ByteArrayAsset(createPermissionsXml(permissions));
+    }
+
+    /**
+     * Creates a new asset with the given contents for a {@code permissions.xml} file.
+     *
+     * @param permissions           the permissions to add to the file
+     * @param additionalPermissions any additional permissions to add to the file
+     *
+     * @return an asset with the given contents for a {@code permissions.xml} file
+     */
+    public static Asset createPermissionsXmlAsset(final Iterable<? extends Permission> permissions,
+            final Permission... additionalPermissions) {
+        return new ByteArrayAsset(createPermissionsXml(permissions, additionalPermissions));
+    }
+
+    /**
+     * Creates a new asset with the given contents for a {@code permissions.xml} file.
+     *
+     * @param permissions the permissions to add to the file
+     *
+     * @return an asset with the given contents for a {@code permissions.xml} file
+     */
+    public static Asset createPermissionsXmlAsset(final Iterable<? extends Permission> permissions) {
+        return new ByteArrayAsset(createPermissionsXml(permissions));
+    }
+
+    /**
+     * Creates a new asset with the given contents for a {@code permissions.xml} file.
+     *
+     * @param permissions the permissions to add to the file
+     *
+     * @return an asset with the given contents for a {@code permissions.xml} file
+     */
+    public static byte[] createPermissionsXml(Permission... permissions) {
+        return createPermissionsXml(List.of(permissions));
+    }
+
+    /**
+     * Creates a new asset with the given contents for a {@code permissions.xml} file.
+     *
+     * @param permissions           the permissions to add to the file
+     * @param additionalPermissions any additional permissions to add to the file
+     *
+     * @return an asset with the given contents for a {@code permissions.xml} file
+     */
+    public static byte[] createPermissionsXml(final Iterable<? extends Permission> permissions,
+            final Permission... additionalPermissions) {
+        XMLStreamWriter writer = null;
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            writer = createWriter(out);
+
+            writer.writeStartDocument("utf-8", "1.0");
+            writer.writeStartElement("permissions");
+            writer.writeNamespace(null, "https://jakarta.ee/xml/ns/jakartaee");
+            writer.writeAttribute("version", "10");
+            addPermissionXml(writer, permissions);
+            if (additionalPermissions != null && additionalPermissions.length > 0) {
+                addPermissionXml(writer, List.of(additionalPermissions));
+            }
+            writer.writeEndElement();
+            writer.writeEndDocument();
+            writer.flush();
+            return out.toByteArray();
+        } catch (IOException | XMLStreamException e) {
+            throw new RuntimeException("Failed to create the permissions.xml file.", e);
+        } finally {
+            if (writer != null)
+                try {
+                    writer.close();
+                } catch (Exception ignore) {
+
+                }
+        }
+    }
+
+    /**
+     * This should only be used as a workaround for issues with API's where something like a
+     * {@link java.util.ServiceLoader} needs access to an implementation.
+     * <p>
+     * Adds file permissions for every JAR in the modules directory. The {@code module.jar.path} system property
+     * <strong>must</strong> be set.
+     * </p>
+     *
+     * @param moduleNames the module names to add file permissions for
+     *
+     * @return a collection of permissions required
+     */
+    public static Collection<Permission> addModuleFilePermission(final String... moduleNames) {
+        final String value = System.getProperty("module.jar.path");
+        if (value == null || value.isBlank()) {
+            return Collections.emptySet();
+        }
+        // Get the module path
+        final Path moduleDir = Path.of(value);
+        final Collection<Permission> result = new ArrayList<>();
+        for (String moduleName : moduleNames) {
+            final Path definedModuleDir = moduleDir.resolve(moduleName.replace('.', File.separatorChar))
+                    .resolve("main");
+            // Find all the JAR's
+            try (Stream<Path> stream = Files.walk(definedModuleDir)) {
+                stream
+                        .filter((path) -> path.getFileName().toString().endsWith(".jar"))
+                        .map((path) -> new FilePermission(path.toAbsolutePath().toString(), "read"))
+                        .forEach(result::add);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Creates the permissions required for the {@code java.io.tmpdir}. This adds permissions to read the directory, then
+     * adds permissions for all files and subdirectories of the temporary directory. The actions are used for the latter
+     * permission.
+     *
+     * @param actions the actions required for the temporary directory
+     *
+     * @return the permissions required
+     */
+    public static Collection<FilePermission> createTempDirPermission(final String actions) {
+        String tempDir = System.getProperty("java.io.tmpdir");
+        // This should never happen, but it's a better error message than an NPE
+        if (tempDir.charAt(tempDir.length() - 1) != File.separatorChar) {
+            tempDir += File.separatorChar;
+        }
+        return List.of(new FilePermission(tempDir, "read"), new FilePermission(tempDir + "-", actions));
+    }
+
+    private static void addPermissionXml(final XMLStreamWriter writer, final Iterable<? extends Permission> permissions)
+            throws XMLStreamException {
+        for (Permission permission : permissions) {
+            writer.writeStartElement("permission");
+
+            writer.writeStartElement("class-name");
+            writer.writeCharacters(permission.getClass().getName());
+            writer.writeEndElement();
+
+            writer.writeStartElement("name");
+            writer.writeCharacters(permission.getName());
+            writer.writeEndElement();
+
+            final String actions = permission.getActions();
+            if (actions != null && !actions.isEmpty()) {
+                writer.writeStartElement("actions");
+                writer.writeCharacters(actions);
+                writer.writeEndElement();
+            }
+            writer.writeEndElement();
+        }
+    }
+
+    private static XMLStreamWriter createWriter(final OutputStream out) throws XMLStreamException {
+        final XMLOutputFactory factory = XMLOutputFactory.newInstance();
+        return new IndentingXmlWriter(factory.createXMLStreamWriter(out, "utf-8"));
+    }
+}

--- a/wildfly-testing-tools/src/main/java/org/wildfly/testing/tools/deployments/IndentingXmlWriter.java
+++ b/wildfly-testing-tools/src/main/java/org/wildfly/testing/tools/deployments/IndentingXmlWriter.java
@@ -1,0 +1,295 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.testing.tools.deployments;
+
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class IndentingXmlWriter implements XMLStreamWriter, XMLStreamConstants {
+
+    private static final String SPACES = "    ";
+
+    private final XMLStreamWriter delegate;
+    private int index;
+    private int state = START_DOCUMENT;
+    private boolean indentEnd;
+
+    IndentingXmlWriter(final XMLStreamWriter delegate) {
+        this.delegate = delegate;
+        index = 0;
+        indentEnd = false;
+    }
+
+    private void indent() throws XMLStreamException {
+        final int index = this.index;
+        if (index > 0) {
+            for (int i = 0; i < index; i++) {
+                delegate.writeCharacters(SPACES);
+            }
+        }
+
+    }
+
+    private void newline() throws XMLStreamException {
+        delegate.writeCharacters(System.lineSeparator());
+    }
+
+    @Override
+    public void writeStartElement(final String localName) throws XMLStreamException {
+        newline();
+        indent();
+        delegate.writeStartElement(localName);
+        indentEnd = false;
+        state = START_ELEMENT;
+        index++;
+    }
+
+    @Override
+    public void writeStartElement(final String namespaceURI, final String localName) throws XMLStreamException {
+        newline();
+        indent();
+        delegate.writeStartElement(namespaceURI, localName);
+        indentEnd = false;
+        state = START_ELEMENT;
+        index++;
+    }
+
+    @Override
+    public void writeStartElement(final String prefix, final String localName, final String namespaceURI)
+            throws XMLStreamException {
+        newline();
+        indent();
+        delegate.writeStartElement(prefix, localName, namespaceURI);
+        indentEnd = false;
+        state = START_ELEMENT;
+        index++;
+    }
+
+    @Override
+    public void writeEmptyElement(final String namespaceURI, final String localName) throws XMLStreamException {
+        newline();
+        indent();
+        delegate.writeEmptyElement(namespaceURI, localName);
+        state = END_ELEMENT;
+    }
+
+    @Override
+    public void writeEmptyElement(final String prefix, final String localName, final String namespaceURI)
+            throws XMLStreamException {
+        newline();
+        indent();
+        delegate.writeEmptyElement(prefix, localName, namespaceURI);
+        state = END_ELEMENT;
+    }
+
+    @Override
+    public void writeEmptyElement(final String localName) throws XMLStreamException {
+        newline();
+        indent();
+        delegate.writeEmptyElement(localName);
+        state = END_ELEMENT;
+    }
+
+    @Override
+    public void writeEndElement() throws XMLStreamException {
+        index--;
+        if (state != CHARACTERS || indentEnd) {
+            newline();
+            indent();
+            indentEnd = false;
+        }
+        delegate.writeEndElement();
+        state = END_ELEMENT;
+    }
+
+    @Override
+    public void writeEndDocument() throws XMLStreamException {
+        delegate.writeEndDocument();
+        state = END_DOCUMENT;
+    }
+
+    @Override
+    public void close() throws XMLStreamException {
+        delegate.close();
+    }
+
+    @Override
+    public void flush() throws XMLStreamException {
+        delegate.flush();
+    }
+
+    @Override
+    public void writeAttribute(final String localName, final String value) throws XMLStreamException {
+        delegate.writeAttribute(localName, value);
+    }
+
+    @Override
+    public void writeAttribute(final String prefix, final String namespaceURI, final String localName, final String value)
+            throws XMLStreamException {
+        delegate.writeAttribute(prefix, namespaceURI, localName, value);
+    }
+
+    @Override
+    public void writeAttribute(final String namespaceURI, final String localName, final String value)
+            throws XMLStreamException {
+        delegate.writeAttribute(namespaceURI, localName, value);
+    }
+
+    @Override
+    public void writeNamespace(final String prefix, final String namespaceURI) throws XMLStreamException {
+        delegate.writeNamespace(prefix, namespaceURI);
+    }
+
+    @Override
+    public void writeDefaultNamespace(final String namespaceURI) throws XMLStreamException {
+        delegate.writeDefaultNamespace(namespaceURI);
+    }
+
+    @Override
+    public void writeComment(final String data) throws XMLStreamException {
+        newline();
+        indent();
+        delegate.writeComment(data);
+        state = COMMENT;
+    }
+
+    @Override
+    public void writeProcessingInstruction(final String target) throws XMLStreamException {
+        newline();
+        indent();
+        delegate.writeProcessingInstruction(target);
+        state = PROCESSING_INSTRUCTION;
+    }
+
+    @Override
+    public void writeProcessingInstruction(final String target, final String data) throws XMLStreamException {
+        newline();
+        indent();
+        delegate.writeProcessingInstruction(target, data);
+        state = PROCESSING_INSTRUCTION;
+    }
+
+    @Override
+    public void writeCData(final String data) throws XMLStreamException {
+        delegate.writeCData(data);
+        state = CDATA;
+    }
+
+    @Override
+    public void writeDTD(final String dtd) throws XMLStreamException {
+        newline();
+        indent();
+        delegate.writeDTD(dtd);
+        state = DTD;
+    }
+
+    @Override
+    public void writeEntityRef(final String name) throws XMLStreamException {
+        delegate.writeEntityRef(name);
+        state = ENTITY_REFERENCE;
+    }
+
+    @Override
+    public void writeStartDocument() throws XMLStreamException {
+        delegate.writeStartDocument();
+        newline();
+        state = START_DOCUMENT;
+    }
+
+    @Override
+    public void writeStartDocument(final String version) throws XMLStreamException {
+        delegate.writeStartDocument(version);
+        newline();
+        state = START_DOCUMENT;
+    }
+
+    @Override
+    public void writeStartDocument(final String encoding, final String version) throws XMLStreamException {
+        delegate.writeStartDocument(encoding, version);
+        newline();
+        state = START_DOCUMENT;
+    }
+
+    @Override
+    public void writeCharacters(final String text) throws XMLStreamException {
+        indentEnd = false;
+        boolean first = true;
+        final Iterator<String> iterator = Stream.of(text.split("\n")).iterator();
+        while (iterator.hasNext()) {
+            final String t = iterator.next();
+            // On first iteration if more than one line is required, skip to a new line and indent
+            if (first && iterator.hasNext()) {
+                first = false;
+                newline();
+                indent();
+            }
+            delegate.writeCharacters(t);
+            if (iterator.hasNext()) {
+                newline();
+                indent();
+                indentEnd = true;
+            }
+        }
+        state = CHARACTERS;
+    }
+
+    @Override
+    public void writeCharacters(final char[] text, final int start, final int len) throws XMLStreamException {
+        delegate.writeCharacters(text, start, len);
+    }
+
+    @Override
+    public String getPrefix(final String uri) throws XMLStreamException {
+        return delegate.getPrefix(uri);
+    }
+
+    @Override
+    public void setPrefix(final String prefix, final String uri) throws XMLStreamException {
+        delegate.setPrefix(prefix, uri);
+    }
+
+    @Override
+    public void setDefaultNamespace(final String uri) throws XMLStreamException {
+        delegate.setDefaultNamespace(uri);
+    }
+
+    @Override
+    public void setNamespaceContext(final NamespaceContext context) throws XMLStreamException {
+        delegate.setNamespaceContext(context);
+    }
+
+    @Override
+    public NamespaceContext getNamespaceContext() {
+        return delegate.getNamespaceContext();
+    }
+
+    @Override
+    public Object getProperty(final String name) throws IllegalArgumentException {
+        return delegate.getProperty(name);
+    }
+}

--- a/wildfly-testing-tools/src/test/java/org/wildly/testing/tools/deployments/DeploymentDescriptorsTest.java
+++ b/wildfly-testing-tools/src/test/java/org/wildly/testing/tools/deployments/DeploymentDescriptorsTest.java
@@ -1,0 +1,189 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildly.testing.tools.deployments;
+
+import java.io.InputStream;
+import java.net.SocketPermission;
+import java.security.Permission;
+import java.util.Collection;
+import java.util.Map;
+import java.util.PropertyPermission;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.wildfly.testing.tools.deployments.DeploymentDescriptors;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class DeploymentDescriptorsTest {
+
+    @Test
+    public void jbossWebSecurityDomain() throws Exception {
+        final String expected = generateJBossWebXml(Map.of("security-domain", "test"));
+        try (InputStream in = DeploymentDescriptors.createJBossWebSecurityDomain("test").openStream()) {
+            Assertions.assertEquals(expected, new String(in.readAllBytes()));
+        }
+    }
+
+    @Test
+    public void jbossWebContextRoot() throws Exception {
+        final String expected = generateJBossWebXml(Map.of("context-root", "/test"));
+        try (InputStream in = DeploymentDescriptors.createJBossWebContextRoot("/test").openStream()) {
+            Assertions.assertEquals(expected, new String(in.readAllBytes()));
+        }
+    }
+
+    @Test
+    public void jbossWebXml() throws Exception {
+        final var elements = Map.of("virtual-host", "localhost", "context-root", "/", "security-domain", "ApplicationDomain");
+        final String expected = generateJBossWebXml(elements);
+        try (InputStream in = DeploymentDescriptors.createJBossWebXmlAsset(elements).openStream()) {
+            Assertions.assertEquals(expected, new String(in.readAllBytes()));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("moduleArguments")
+    public void jbossDeploymentStructure(final Set<String> addedModules, final Set<String> excludedModules) {
+        final String expected = generateJBossDeploymentStructure(addedModules, excludedModules);
+        Assertions.assertEquals(expected,
+                new String(DeploymentDescriptors.createJBossDeploymentStructure(addedModules, excludedModules)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("permissions")
+    public void permissionsXml(final Set<Permission> permissions) {
+        final String expected = generatePermissionsXml(permissions);
+        Assertions.assertEquals(expected,
+                new String(DeploymentDescriptors.createPermissionsXml(permissions)));
+    }
+
+    static Stream<Arguments> moduleArguments() {
+        return Stream.of(
+                Arguments.of(Named.of("addedModules", Set.of("org.wildfly.arquillian", "org.wildfly.arquillian.test")),
+                        Named.of("excludedModules", Set.of())),
+                Arguments.of(Named.of("addedModules", Set.of("org.wildfly.arquillian", "org.wildfly.arquillian.test")),
+                        Named.of("excludedModules", Set.of("org.jboss.as.logging"))),
+                Arguments.of(Named.of("addedModules", Set.of()),
+                        Named.of("excludedModules", Set.of("org.jboss.as.logging"))));
+    }
+
+    static Stream<Arguments> permissions() {
+        return Stream.of(
+                Arguments.of(Set.of(new RuntimePermission("test.permissions", "action1"))),
+                Arguments.of(Set.of(new SocketPermission("localhost", "connect,resolve"),
+                        new PropertyPermission("java.io.tmpdir", "read"),
+                        new PropertyPermission("test.property", "read,write"))));
+    }
+
+    private static String generateJBossWebXml(final Map<String, String> elements) {
+        final StringBuilder xml = new StringBuilder()
+                .append("<?xml version=\"1.0\" encoding=\"utf-8\"?>")
+                .append(System.lineSeparator())
+                .append(System.lineSeparator())
+                .append("<jboss-web>")
+                .append(System.lineSeparator());
+        for (var element : elements.entrySet()) {
+            xml.append("    <")
+                    .append(element.getKey())
+                    .append('>')
+                    .append(element.getValue())
+                    .append("</")
+                    .append(element.getKey())
+                    .append(">")
+                    .append(System.lineSeparator());
+        }
+        xml.append("</jboss-web>");
+        return xml.toString();
+    }
+
+    private static String generateJBossDeploymentStructure(final Set<String> addedModules, final Set<String> excludedModules) {
+        final StringBuilder xml = new StringBuilder()
+                .append("<?xml version=\"1.0\" encoding=\"utf-8\"?>")
+                .append(System.lineSeparator())
+                .append(System.lineSeparator())
+                .append("<jboss-deployment-structure>")
+                .append(System.lineSeparator())
+                .append("    <deployment>")
+                .append(System.lineSeparator());
+        if (!addedModules.isEmpty()) {
+            xml.append("        <dependencies>")
+                    .append(System.lineSeparator());
+            for (String module : addedModules) {
+                xml.append("            <module name=\"").append(module).append("\">")
+                        .append(System.lineSeparator())
+                        .append("            </module>")
+                        .append(System.lineSeparator());
+            }
+            xml.append("        </dependencies>")
+                    .append(System.lineSeparator());
+        }
+        if (!excludedModules.isEmpty()) {
+            xml.append("        <exclusions>")
+                    .append(System.lineSeparator());
+            for (String module : addedModules) {
+                xml.append("            <module name=\"").append(module).append("\">")
+                        .append(System.lineSeparator())
+                        .append("            </module>")
+                        .append(System.lineSeparator());
+            }
+            xml.append("        </exclusions>")
+                    .append(System.lineSeparator());
+        }
+
+        xml.append("    </deployment>")
+                .append(System.lineSeparator())
+                .append("</jboss-deployment-structure>");
+        return xml.toString();
+    }
+
+    private static String generatePermissionsXml(final Collection<Permission> permissions) {
+        final StringBuilder xml = new StringBuilder()
+                .append("<?xml version=\"1.0\" encoding=\"utf-8\"?>")
+                .append(System.lineSeparator())
+                .append(System.lineSeparator())
+                .append("<permissions xmlns=\"https://jakarta.ee/xml/ns/jakartaee\" version=\"10\">")
+                .append(System.lineSeparator());
+        for (Permission permission : permissions) {
+            xml.append("    <permission>")
+                    .append(System.lineSeparator())
+                    .append("        <class-name>").append(permission.getClass().getName()).append("</class-name>")
+                    .append(System.lineSeparator())
+                    .append("        <name>").append(permission.getName()).append("</name>")
+                    .append(System.lineSeparator());
+            final String actions = permission.getActions();
+            if (actions != null && !actions.isEmpty()) {
+                xml.append("        <actions>").append(actions).append("</actions>")
+                        .append(System.lineSeparator());
+            }
+            xml.append("    </permission>")
+                    .append(System.lineSeparator());
+        }
+        xml.append("</permissions>");
+        return xml.toString();
+    }
+}


### PR DESCRIPTION
### [WFARQ-167](https://issues.redhat.com/browse/WFARQ-167)

This enriches `ServerSetupTask` implementations to allow them to inject resources. For example:
```java
@ArquillianResource
private ManagementClient client;
```
---
### [WFARQ-169](https://issues.redhat.com/browse/WFARQ-169)

This adds some simple helper methods to the `ServerSetupTask` to allow executing management operations.

---
### [WFARQ-168](https://issues.redhat.com/browse/WFARQ-168)

This changes the `ServerSetupTask` to re-throw all exceptions. Please note this could potentially break some implementations. However, that's an indicator your implementation is broken and should be fixed.

---
### [WFARQ-165](https://issues.redhat.com/browse/WFARQ-165)

This upgrades the `org.wildfly.plugins:wildfly-plugin-tools` to 1.1.0.Final. It adds the ability to inject a `ServerManager` for usage in tests and other resources.

It adds a `DeploymentDescriptor` for creating deployment descriptors like a `jboss-web.xml`,  `jboss-deployment-structure.xml` or a `permissions.xml` file.

There are also some helper `ServerSetupTask`'s which are common in WildFly and other projects.
