### PR TITLE
[WFARQ-196] Migrate to using the new WildFly Launcher API GAV.

### DIFF
--- a/bom/project-bom/pom.xml
+++ b/bom/project-bom/pom.xml
@@ -24,6 +24,7 @@
     <properties>
         <version.org.wildfly.core>26.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.full>31.0.1.Final</version.org.wildfly.full>
+        <version.org.wildfly.launcher>1.0.0.Beta1</version.org.wildfly.launcher>
         <version.io.smallrye.jandex>3.1.6</version.io.smallrye.jandex>
         <version.junit>4.13.2</version.junit>
         <version.org.junit>5.11.3</version.org.junit>
@@ -247,9 +248,9 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.wildfly.core</groupId>
+                <groupId>org.wildfly.launcher</groupId>
                 <artifactId>wildfly-launcher</artifactId>
-                <version>${version.org.wildfly.core}</version>
+                <version>${version.org.wildfly.launcher}</version>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.core</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -67,7 +67,7 @@
             <artifactId>wildfly-controller-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly.core</groupId>
+            <groupId>org.wildfly.launcher</groupId>
             <artifactId>wildfly-launcher</artifactId>
         </dependency>
         <dependency>

--- a/container-bootable/pom.xml
+++ b/container-bootable/pom.xml
@@ -51,7 +51,7 @@
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly.core</groupId>
+            <groupId>org.wildfly.launcher</groupId>
             <artifactId>wildfly-launcher</artifactId>
         </dependency>
         <!-- Test Dependencies -->

--- a/container-managed-domain/pom.xml
+++ b/container-managed-domain/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>wildfly-arquillian-common-domain</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly.core</groupId>
+            <groupId>org.wildfly.launcher</groupId>
             <artifactId>wildfly-launcher</artifactId>
         </dependency>
 

--- a/container-managed/pom.xml
+++ b/container-managed/pom.xml
@@ -63,7 +63,7 @@
             <artifactId>remoting-jmx</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly.core</groupId>
+            <groupId>org.wildfly.launcher</groupId>
             <artifactId>wildfly-launcher</artifactId>
         </dependency>
         <!-- Test Dependencies -->


### PR DESCRIPTION
https://issues.redhat.com/browse/WFARQ-196