### PR TITLE
[WFARQ-201] Add explicit dependency on slf4j where needed. This depen…

### DIFF
--- a/bom/project-bom/pom.xml
+++ b/bom/project-bom/pom.xml
@@ -260,6 +260,12 @@
                 <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-server</artifactId>
                 <version>${version.org.wildfly.core}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.plugins</groupId>

--- a/common-domain/pom.xml
+++ b/common-domain/pom.xml
@@ -57,6 +57,11 @@
           <groupId>org.jboss.arquillian.container</groupId>
           <artifactId>arquillian-container-test-impl-base</artifactId>
         </dependency>
+        <!-- Required by the wildfly-controller-client transitive dependency org.apache.sshd:sshd-common -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller-client</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -62,6 +62,11 @@
             <groupId>org.jboss.remotingjmx</groupId>
             <artifactId>remoting-jmx</artifactId>
         </dependency>
+        <!-- Required by the wildfly-controller-client transitive dependency org.apache.sshd:sshd-common -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller-client</artifactId>

--- a/container-embedded/pom.xml
+++ b/container-embedded/pom.xml
@@ -61,6 +61,11 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>
+        <!-- Required by the wildfly-protocol transitive dependency org.apache.sshd:sshd-common -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-protocol</artifactId>

--- a/protocol-jmx/pom.xml
+++ b/protocol-jmx/pom.xml
@@ -64,6 +64,11 @@
             <groupId>org.jboss.remotingjmx</groupId>
             <artifactId>remoting-jmx</artifactId>
         </dependency>
+        <!-- Required by the wildfly-server transitive dependency org.apache.sshd:sshd-common -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-jmx</artifactId>

--- a/testenricher-msc/pom.xml
+++ b/testenricher-msc/pom.xml
@@ -61,6 +61,11 @@
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>
         </dependency>
+        <!-- Required by the wildfly-server transitive dependency org.apache.sshd:sshd-common -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-server</artifactId>

--- a/wildfly-testing-tools/pom.xml
+++ b/wildfly-testing-tools/pom.xml
@@ -33,6 +33,11 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- Required by the wildfly-controller-client transitive dependency org.apache.sshd:sshd-common -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller-client</artifactId>


### PR DESCRIPTION
…dency is excluded from various WildFly Client dependencies, but required and fails silently. Adding an explicit dependency is the best option.

https://issues.redhat.com/browse/WFARQ-201