### PR TITLE
WFARQ-207 Remote container: NoSuchMethodError:'Logger.getMessageLogger'

### DIFF
--- a/common-domain/pom.xml
+++ b/common-domain/pom.xml
@@ -57,6 +57,11 @@
           <groupId>org.jboss.arquillian.container</groupId>
           <artifactId>arquillian-container-test-impl-base</artifactId>
         </dependency>
+        <!-- Ensure an old version of jboss-logging is not brought in transitively -->
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
         <!-- Required by the wildfly-controller-client transitive dependency org.apache.sshd:sshd-common -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -57,6 +57,11 @@
           <groupId>org.jboss.arquillian.protocol</groupId>
           <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
         </dependency>
+        <!-- Ensure an old version of jboss-logging is not brought in transitively -->
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
         <!-- Required for the JMX MBeanServerConnection -->
         <dependency>
             <groupId>org.jboss.remotingjmx</groupId>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/WFARQ-207