### PR TITLE
Fix logging inefficiencies in debug/trace calls: use debugf format st…

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/MBeanServerConnectionProvider.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/MBeanServerConnectionProvider.java
@@ -45,7 +45,7 @@ public final class MBeanServerConnectionProvider implements Closeable {
                 "service:jmx:remote+http://" + NetworkUtils.formatPossibleIpv6Address(host) + ":" + port);
         try {
             if (jmxConnector == null) {
-                log.debug("Connecting JMXConnector to: " + urlString);
+                log.debugf("Connecting JMXConnector to: %s", urlString);
                 JMXServiceURL serviceURL = new JMXServiceURL(urlString);
                 jmxConnector = JMXConnectorFactory.connect(serviceURL, null);
             }

--- a/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/JMXProtocolPackager.java
+++ b/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/JMXProtocolPackager.java
@@ -221,7 +221,9 @@ public class JMXProtocolPackager implements DeploymentPackager {
         archive.addAsManifestResource("META-INF/permissions.xml", "permissions.xml");
 
         log.debugf("Loadable extensions: %s", loadableExtensions);
-        log.tracef("Archive content: %s\n%s", archive, archive.toString(true));
+        if (log.isTraceEnabled()) {
+            log.tracef("Archive content: %s\n%s", archive, archive.toString(true));
+        }
         return archive;
     }
 


### PR DESCRIPTION
…ring instead of string concatenation and guard expensive archive.toString(true) with isTraceEnabled() in JMXProtocolPackager

Random spotting.