### PR TITLE
[WFARQ-234] Use the default startup timeout for the @ReloadIfRequired…

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/api/ReloadIfRequired.java
+++ b/common/src/main/java/org/jboss/as/arquillian/api/ReloadIfRequired.java
@@ -27,11 +27,12 @@ import org.jboss.as.arquillian.container.ManagementClient;
 public @interface ReloadIfRequired {
 
     /**
-     * The time to wait for the reload to happen. The default is {@code 10}.
+     * The time to wait for the reload to happen. A value of 0 or less means the value of
+     * {@code startupTimeoutInSeconds} defined in the container's configuration.
      *
      * @return the default time to wait for a reload
      */
-    long value() default 10L;
+    long value() default 0L;
 
     /**
      * The time unit used for the timeout to wait for a reload. The default is {@link TimeUnit#SECONDS SECONDS}.

--- a/common/src/main/java/org/jboss/as/arquillian/container/CommonManagedContainerConfiguration.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/CommonManagedContainerConfiguration.java
@@ -22,13 +22,18 @@ import org.jboss.arquillian.container.spi.client.deployment.Validate;
 public class CommonManagedContainerConfiguration extends CommonContainerConfiguration {
 
     /**
+     * The default startup timeout in seconds.
+     */
+    static final int DEFAULT_STARTUP_TIMEOUT = 60;
+
+    /**
      * Default timeout value waiting on ports is 10 seconds
      */
     private static final Integer DEFAULT_VALUE_WAIT_FOR_PORTS_TIMEOUT_SECONDS = 10;
 
     private String javaHome = System.getenv("JAVA_HOME");
 
-    private int startupTimeoutInSeconds = 60;
+    private int startupTimeoutInSeconds = DEFAULT_STARTUP_TIMEOUT;
 
     private int stopTimeoutInSeconds = 60;
 

--- a/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
@@ -115,7 +115,13 @@ public class ServerSetupObserver {
         }
 
         final ManagementClient client = managementClient.get();
-        final ServerSetupTaskHolder holder = new ServerSetupTaskHolder(serverManager.get(), client, container.getName());
+        final var deployableContainer = container.getDeployableContainer();
+        int reloadTimeout = CommonManagedContainerConfiguration.DEFAULT_STARTUP_TIMEOUT;
+        if (deployableContainer instanceof CommonManagedDeployableContainer<?> commonManagedDeployableContainer) {
+            reloadTimeout = commonManagedDeployableContainer.getContainerConfiguration().getStartupTimeoutInSeconds();
+        }
+        final ServerSetupTaskHolder holder = new ServerSetupTaskHolder(serverManager.get(), client, containerName,
+                reloadTimeout);
         executeSetup(holder, setup, containerName, event.getDeployment());
     }
 
@@ -236,15 +242,17 @@ public class ServerSetupObserver {
         private final ServerManager serverManager;
         private final Deque<ServerSetupTask> setupTasks;
         private final Set<DeploymentDescription> deployments;
-        private final String containerName;;
+        private final String containerName;
+        private final int reloadTimeout;
 
         private ServerSetupTaskHolder(final ServerManager serverManager, final ManagementClient client,
-                final String containerName) {
+                final String containerName, final int reloadTimeout) {
             this.client = client;
             this.serverManager = serverManager;
             setupTasks = new ArrayDeque<>();
             deployments = new HashSet<>();
             this.containerName = containerName;
+            this.reloadTimeout = reloadTimeout;
         }
 
         void setup(final ServerSetup setup, final String containerName) throws Throwable {
@@ -260,7 +268,7 @@ public class ServerSetupObserver {
                 } finally {
                     if (task.getClass().isAnnotationPresent(ReloadIfRequired.class) && serverManager != null) {
                         final ReloadIfRequired reloadIfRequired = task.getClass().getAnnotation(ReloadIfRequired.class);
-                        serverManager.reloadIfRequired(reloadIfRequired.value(), reloadIfRequired.timeUnit());
+                        serverManager.reloadIfRequired(resolveTimeout(reloadIfRequired), reloadIfRequired.timeUnit());
                     }
                 }
             }
@@ -286,7 +294,7 @@ public class ServerSetupObserver {
                         if (task.getClass().isAnnotationPresent(ReloadIfRequired.class) && serverManager != null) {
                             try {
                                 final ReloadIfRequired reloadIfRequired = task.getClass().getAnnotation(ReloadIfRequired.class);
-                                serverManager.reloadIfRequired(reloadIfRequired.value(), reloadIfRequired.timeUnit());
+                                serverManager.reloadIfRequired(resolveTimeout(reloadIfRequired), reloadIfRequired.timeUnit());
                             } catch (IOException e) {
                                 log.errorf(e, "Failed to reload server. The server may still be in reload-required state.");
                             }
@@ -318,6 +326,13 @@ public class ServerSetupObserver {
             } finally {
                 containerContext.get().deactivate();
             }
+        }
+
+        private long resolveTimeout(final ReloadIfRequired reloadIfRequired) {
+            if (reloadIfRequired.value() <= 0) {
+                return reloadTimeout;
+            }
+            return reloadIfRequired.value();
         }
     }
 }


### PR DESCRIPTION
… annotation instead of a short 10-second timeout. The default value is defined in the containers configuration. However, we will allow the annotation to override it.

https://redhat.atlassian.net/browse/WFARQ-234