### PR TITLE
[WFARQ-248] Use stopTimeoutInSeconds for process wait in stopInternal()

### DIFF
--- a/common/src/main/java/org/jboss/as/arquillian/container/CommonManagedDeployableContainer.java
+++ b/common/src/main/java/org/jboss/as/arquillian/container/CommonManagedDeployableContainer.java
@@ -220,7 +220,7 @@ public abstract class CommonManagedDeployableContainer<T extends CommonManagedCo
                     }
                 }
 
-                final int timeoutSeconds = getContainerConfiguration().getStartupTimeoutInSeconds();
+                final int timeoutSeconds = getContainerConfiguration().getStopTimeoutInSeconds();
                 if (!process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
                     // Log a warning indicating the timeout happened
                     logger.warnf("The container process did not exit within %d seconds. Forcibly destroying the process.",


### PR DESCRIPTION
stopInternal() was using getStartupTimeoutInSeconds() for the process.waitFor() timeout instead of getStopTimeoutInSeconds(). The domain container already uses the correct getter.

https://redhat.atlassian.net/browse/WFARQ-248